### PR TITLE
Fixed _leaderboard_loaded types and removed updateLeaderboardHandle function

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -8,7 +8,6 @@ Steam* Steam::singleton = NULL;
 
 Steam::Steam(){
 	isInitSuccess = false;
-	is_valid = false;
 	singleton = this;
 	tickets.clear();
 }
@@ -706,13 +705,9 @@ void Steam::_number_of_current_players(NumberOfCurrentPlayers_t *callData, bool 
 }
 // Signal a leaderboard has been loaded or has failed
 void Steam::_leaderboard_loaded(LeaderboardFindResult_t *callData, bool bIOFailure){
-	if(callData->m_bLeaderboardFound == 0){
-		emit_signal("leaderboard_loaded", "");
-	}
-	else{
-		uint8 sLeaderboard = callData->m_hSteamLeaderboard;
-		emit_signal("leaderboard_loaded", sLeaderboard);
-	}
+	leaderboard_handle = callData->m_hSteamLeaderboard;
+	uint8_t bFound = callData->m_bLeaderboardFound;
+	emit_signal("leaderboard_loaded", leaderboard_handle, bFound);
 }
 // Signal a leaderboard entry has been uploaded
 void Steam::_leaderboard_uploaded(LeaderboardScoreUploaded_t *callData, bool bIOFailure){
@@ -1042,14 +1037,6 @@ void Steam::getDownloadedLeaderboardEntry(SteamLeaderboardEntries_t eHandle, int
 	}
 	memdelete(entry);
 }
-// Update the currently used leaderboard handle
-void Steam::updateLeaderboardHandle(SteamLeaderboard_t lHandle){
-	leaderboard_handle = (uint64)lHandle;
-	is_valid = false;
-	if(leaderboard_handle > 0 && SteamUserStats() != NULL){
-		is_valid = true;
-	}
-}
 // Get the currently used leaderboard handle
 uint64_t Steam::getLeaderboardHandle(){
 	return leaderboard_handle;
@@ -1302,7 +1289,7 @@ void Steam::_bind_methods(){
 	ADD_SIGNAL(MethodInfo("join_requested", PropertyInfo(Variant::INT, "from"), PropertyInfo(Variant::STRING, "connect_string")));
 	ADD_SIGNAL(MethodInfo("avatar_loaded", PropertyInfo(Variant::INT, "size")));
 	ADD_SIGNAL(MethodInfo("number_of_current_players", PropertyInfo(Variant::BOOL, "success"), PropertyInfo(Variant::INT, "players")));
-	ADD_SIGNAL(MethodInfo("leaderboard_loaded", PropertyInfo(Variant::OBJECT, "Steam")));
+	ADD_SIGNAL(MethodInfo("leaderboard_loaded", PropertyInfo(Variant::INT, "leaderboard"), PropertyInfo(Variant::INT, "found")));
 	ADD_SIGNAL(MethodInfo("leaderboard_uploaded", PropertyInfo(Variant::BOOL, "success"), PropertyInfo(Variant::INT, "score"), PropertyInfo(Variant::BOOL, "score_changed"), PropertyInfo(Variant::INT, "global_rank_new"), PropertyInfo(Variant::INT, "global_rank_previous")));
 	ADD_SIGNAL(MethodInfo("leaderboard_entries_loaded"));
 	ADD_SIGNAL(MethodInfo("overlay_toggled", PropertyInfo(Variant::BOOL, "active")));

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -133,7 +133,6 @@ public:
 	void downloadLeaderboardEntriesForUsers(Array usersID);
 	void uploadLeaderboardScore(int score, bool keepBest=false);
 	void getDownloadedLeaderboardEntry(SteamLeaderboardEntries_t eHandle, int entryCount);
-	void updateLeaderboardHandle(SteamLeaderboard_t lHandle);
 	uint64_t getLeaderboardHandle();
 	Array getLeaderboardEntries();
 	bool getAchievementAndUnlockTime(const String& name, bool achieved, int unlockTime);
@@ -163,7 +162,6 @@ protected:
 
 private:
 	bool isInitSuccess;
-	bool is_valid;
 
 	SteamLeaderboard_t leaderboard_handle;
 	Array leaderboard_entries;


### PR DESCRIPTION
Note: I've removed the updateLeaderboardHandle since it's no longer necessary. Now this will work as the Steamworks docs explain, that is just call findLeaderboard and you're ready to use the leaderboard functions.