### PR TITLE
can_build() now takes 1 argument instead of 2

### DIFF
--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -1,4 +1,4 @@
-def can_build(env, platform):
+def can_build(platform):
   return platform=="x11" or platform=="windows" or platform=="osx"
 
 def configure(env):


### PR DESCRIPTION
This should keep things consistent with SCons, see this issue on the Godot repo https://github.com/godotengine/godot/issues/22195 

Same error but with the GodotSteam module instead of ARVR.