### PR TITLE
Added the possibility to upload/download details for Leaderboards

### DIFF
--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -271,10 +271,11 @@ class Steam: public Object {
 		int getLeaderboardEntryCount();
 		void downloadLeaderboardEntries(int start, int end, int type=GLOBAL);
 		void downloadLeaderboardEntriesForUsers(Array usersID);
-		void uploadLeaderboardScore(int score, bool keepBest=false);
+		void uploadLeaderboardScore(int score, bool keepBest=false, PoolIntArray details=PoolIntArray());
 		void getDownloadedLeaderboardEntry(SteamLeaderboardEntries_t handle, int entryCount);
 		uint64_t getLeaderboardHandle();
 		Array getLeaderboardEntries();
+		void setLeaderboardDetailsMax(int detailsMax);
 		bool getAchievementAndUnlockTime(const String& name, bool achieved, uint32_t unlockTime);
 		bool indicateAchievementProgress(const String& name, int currentProgress, int maxProgress);
 		// Utils ////////////////////////////////////
@@ -324,6 +325,7 @@ class Steam: public Object {
 		// Leaderboards
 		SteamLeaderboard_t leaderboardHandle;
 		Array leaderboardEntries;
+		int leaderboardDetailsMax;
 		// User stats
 		int numAchievements;
 		bool statsInitialized;


### PR DESCRIPTION
The function `uploadLeaderboardScore` now has a third argument to be able to pass details to the leaderboards.
Also use `setLeaderboardDetailsMax` before calling `getLeaderboardEntries` to include details on the array.