### PR TITLE
Added JoinGameRequested

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -1751,12 +1751,18 @@ void Steam::_lobby_invite(LobbyInvite_t* lobbyData){
 	uint64_t game = gameID.ConvertToUint64();
 	emit_signal("lobby_invite", inviter, lobby, game);
 }
-// Signal a game/lobby join has been requested.
+// Signal a lobby join has been requested.
 void Steam::_join_requested(GameLobbyJoinRequested_t* callData){
 	uint64_t steamID = callData->m_steamIDFriend.GetAccountID();
 	CSteamID lobbyID = callData->m_steamIDLobby;
 	uint64_t lobby = lobbyID.ConvertToUint64();
 	emit_signal("join_requested", steamID, lobby);
+}
+// Signal that a game join has been requested
+void Steam::_join_game_requested(GameRichPresenceJoinRequested_t* callData){
+	uint64_t steamID = callData->m_steamIDFriend.GetAccountID();
+	String con_string = callData->m_rgchConnect;
+	emit_signal("join_game_requested", steamID, con_string);
 }
 // Signal that the avatar has been loaded.
 void Steam::_avatar_loaded(AvatarImageLoaded_t* avatarData){

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -392,6 +392,7 @@ class Steam: public Object {
 		STEAM_CALLBACK(Steam, _lobby_invite, LobbyInvite_t);
 		STEAM_CALLBACK(Steam, _lobby_game_created, LobbyGameCreated_t);
 		STEAM_CALLBACK(Steam, _join_requested, GameLobbyJoinRequested_t);
+		STEAM_CALLBACK(Steam, _join_game_requested, GameRichPresenceJoinRequested_t);
 		STEAM_CALLBACK(Steam, _server_connected, SteamServersConnected_t);
 		STEAM_CALLBACK(Steam, _server_disconnected, SteamServersDisconnected_t);
 		CCallResult<Steam, LobbyMatchList_t> callResultLobbyList;


### PR DESCRIPTION
So, just added back the JoinGameRequest which uses GameRichPresenceJoinRequested_t. Should work fine, it's just like it was before. So now we have JoinGameRequest and JoinRequest Callbacks, first one is for running games and second for lobbies #60 