### PR TITLE
Added getNumLobbyMembers method

### DIFF
--- a/include/godotsteam.h
+++ b/include/godotsteam.h
@@ -123,6 +123,7 @@ class Steam : public GodotScript<Reference>{
 		bool inviteUserToLobby(uint64_t steamIDLobby, uint64_t steamIDInvitee);
 		bool setLobbyData(uint64_t lobbyID, String key, String value);
 		String getLobbyData(uint64_t steamIDLobby, String key);
+		int getNumLobbyMembers(uint64_t steamIDLobby);
 		Array getLobbyMembersData(uint64_t steamIDLobby);
 		// Music ////////////////////////////////////
 		bool musicIsEnabled();
@@ -406,6 +407,7 @@ class Steam : public GodotScript<Reference>{
 			register_method("inviteUserToLobby", &Steam::inviteUserToLobby);
 			register_method("setLobbyData", &Steam::setLobbyData);
 			register_method("getLobbyData", &Steam::getLobbyData);
+			register_method("getNumLobbyMembers", &Steam::getNumLobbyMembers);
 			register_method("getLobbyMembersData", &Steam::getLobbyMembersData);
 			// Music Bind Methods ///////////////////////
 			register_method("musicIsEnabled", &Steam::musicIsEnabled);

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -756,8 +756,20 @@ bool Steam::inviteUserToLobby(uint64_t steamIDLobby, uint64_t steamIDInvitee){
 	return SteamMatchmaking()->InviteUserToLobby(lobbyID, inviteeID);
 }
 
+int Steam::getNumLobbyMembers(uint64_t steamIDLobby) {
+	if (SteamMatchmaking() == NULL) {
+		return 0;
+	}
+	CSteamID lobbyID = createSteamID(steamIDLobby);
+	return SteamMatchmaking()->GetNumLobbyMembers(lobbyID);
+}
+
 Array Steam::getLobbyMembersData(uint64_t steamIDLobby) {
 	lobbyMembersData.clear();
+	if (SteamMatchmaking() == NULL) {
+		return lobbyMembersData;
+	}
+
 	CSteamID lobbyID = createSteamID(steamIDLobby);
 
 	// list of users in lobby


### PR DESCRIPTION
Small additional utility method for getting number of lobby members. Can be used, for example, to sort out already full lobbies that cannot accept new players at the moment.