### PR TITLE
Static linking + code cleaning + Visual Studio solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+**/.vs/
+**/*.sdf
+**/*.VC.opendb
+**/Debug/
+**/Generated\ Files/
+**/Release/
+**/ipch/
+**/*.obj
+**/*.VC.db

--- a/SConstruct
+++ b/SConstruct
@@ -45,7 +45,7 @@ if target_platform == 'linux' or target_platform == 'x11':
 	if ARGUMENTS.get('use_llvm', 'no') == 'yes':
 		env['CXX'] = 'clang++'
 	env.Append(CCFLAGS = [ '-fPIC', '-g', '-O3', '-std=c++14' ])
-	env.Append(LINKFLAGS = [ '-Wl,-R,\'$$ORIGIN\'' ])
+	env.Append(LINKFLAGS = [ '-Wl,-R,\'$$ORIGIN\'', '-static-libgcc', '-static-libstdc++' ])
 	# If 32-bit
 	if target_arch == '32':
 		env.Append(CCFLAGS = [ '-m32' ])
@@ -69,9 +69,9 @@ if target_platform == 'windows':
 		# Set compiler variables
 		env.Append(LINKFLAGS = [ '/WX' ])
 		if target == 'debug':
-			env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '/MDd' ])
+			env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '/MTd' ])
 		else:
-			env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '/MD' ])
+			env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '/MT' ])
 	# If the host is not actually Windows
 	else:
 		# Set compiler variables

--- a/VisualC/GodotSteam.sln
+++ b/VisualC/GodotSteam.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GodotSteam", "GodotSteam.vcxproj", "{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Debug|x64.ActiveCfg = Debug|x64
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Debug|x64.Build.0 = Debug|x64
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Debug|x86.ActiveCfg = Debug|Win32
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Debug|x86.Build.0 = Debug|Win32
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Release|x64.ActiveCfg = Release|x64
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Release|x64.Build.0 = Release|x64
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Release|x86.ActiveCfg = Release|Win32
+		{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/VisualC/GodotSteam.vcxproj
+++ b/VisualC/GodotSteam.vcxproj
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{EDF37566-4B2D-4837-A796-EC1D3FFCF7E1}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>GodotSteam</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\godot-cpp\include;..\..\godot-cpp\include\core;..\..\godot-cpp\include\gen;..\..\godot-cpp\godot_headers;..\include;..\include\sdk\public\steam;..\include\sdk\public;</IncludePath>
+    <LibraryPath>..\include\sdk\redistributable_bin;..\..\godot-cpp\bin;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <SourcePath>$(VC_SourcePath);..\src;</SourcePath>
+    <TargetName>godotsteam.windows.32</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\godot-cpp\include;..\..\godot-cpp\include\core;..\..\godot-cpp\include\gen;..\..\godot-cpp\godot_headers;..\include;..\include\sdk\public\steam;..\include\sdk\public;</IncludePath>
+    <LibraryPath>..\include\sdk\redistributable_bin\win64;..\..\godot-cpp\bin;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <SourcePath>$(VC_SourcePath);..\src;</SourcePath>
+    <TargetName>godotsteam.windows.64</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\godot-cpp\include;..\..\godot-cpp\include\core;..\..\godot-cpp\include\gen;..\..\godot-cpp\godot_headers;..\include;..\include\sdk\public\steam;..\include\sdk\public;</IncludePath>
+    <LibraryPath>..\include\sdk\redistributable_bin;..\..\godot-cpp\bin;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <SourcePath>$(VC_SourcePath);..\src;</SourcePath>
+    <TargetName>godotsteam.windows.32</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);..\..\godot-cpp\include;..\..\godot-cpp\include\core;..\..\godot-cpp\include\gen;..\..\godot-cpp\godot_headers;..\include;..\include\sdk\public\steam;..\include\sdk\public;</IncludePath>
+    <LibraryPath>..\include\sdk\redistributable_bin\win64;..\..\godot-cpp\bin;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <SourcePath>$(VC_SourcePath);..\src;</SourcePath>
+    <TargetName>godotsteam.windows.64</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_WINDOWS;_USRDLL;GDNATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgodot-cpp.windows.debug.32.lib;steam_api.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;GDNATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgodot-cpp.windows.debug.64.lib;steam_api64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_WINDOWS;_USRDLL;GDNATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgodot-cpp.windows.release.32.lib;steam_api.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;GDNATIVE_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libgodot-cpp.windows.release.64.lib;steam_api64.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\godotsteam.cpp" />
+    <ClCompile Include="..\src\init.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\godotsteam.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/VisualC/GodotSteam.vcxproj.filters
+++ b/VisualC/GodotSteam.vcxproj.filters
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\src\godotsteam.cpp" />
+    <ClCompile Include="..\src\init.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\include\godotsteam.h" />
+  </ItemGroup>
+</Project>

--- a/VisualC/GodotSteam.vcxproj.user
+++ b/VisualC/GodotSteam.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -785,14 +785,11 @@ Array Steam::getLobbyMembersData(uint64_t steamIDLobby) {
 	for (int i = 0; i < cLobbyMembers; i++) {
 		CSteamID steamIDLobbyMember = SteamMatchmaking()->GetLobbyMemberByIndex(lobbyID, i);
 
-		const char *pchReady = SteamMatchmaking()->GetLobbyMemberData(lobbyID, steamIDLobbyMember, "ready");
-		bool bReady = (pchReady && atoi(pchReady) == 1);
 		bool bLobbyOwner = steamIDLobbyMember == steamIDLobbyOwner;
 		Dictionary entryDict;
 		uint64_t lobbyMemberID = (uint64_t)steamIDLobbyMember.ConvertToUint64();
 		entryDict["steamIDLobbyMember"] = lobbyMemberID;
 		entryDict["steamAccountIDLobbyMember"] = steamIDLobbyMember.GetAccountID();
-		entryDict["ready"] = bReady;
 		entryDict["owner"] = bLobbyOwner;
 		lobbyMembersData.append(entryDict);
 	}


### PR DESCRIPTION
I've added flags for static linking we discussed... You said that library works on Linux when you compiled it yourself, maybe this flags helped too :)
Also I've changed linker flags for Windows with the same purpose, namely I've replaced /MD with /MT and /MDd with /MTd. As I've said, this helped to fix library on my friend's machine.
Please note, that you should change this flags for GodotNativeTools/godot-cpp too when compiling.
Another small change: I've removed fetching of custom lobby member data "ready" from the function getLobbyMembersData(). This code was copy-pasted by me from the Valve example application SpaceWar and it is really not needed, Anyway, getLobbyMembersData() returns you steamIDLobbyMember, therefore you can later call GetLobbyMemberData().
The last feature here is the ready Visual Studio solution directory! Now all you need to do to compile GodotSteam on Windows is:
1) Create some folder, for example, GDNative
2) Checkout https://github.com/GodotNativeTools/godot-cpp to GDNative folder 
3) Build godot-cpp (requires SCons, can be tricky on Windows)
**Please note, that you should manually change /MD to /MT and /MDd to /MTd in godot-cpp's SConstruct file to enable static linking of the Visual C runtime or you can not be able to compile GodotSteam!**
4) Checkout GodotSteam
5) Copy `public` and `redistributable_bin` folders from Steam SDK to `GodotSteam\include\sdk`
7) Open solution file `GodotSteam\VisualC\GodotSteam.sln` in Visual Studio (I used Visual Studio Community 2015, I believe that later versions like 2017 and 2019 can convert this solution file to their format)
8) Select your desired configuration and build! Both debug and release versions & 32 and 64-bit architectures are supported, just make sure that you've compiled the corresponding version of godot-cpp.
