### PR TITLE
added game info reference return to getFriendGamePlayed

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -509,13 +509,25 @@ String Steam::getFriendPersonaName(uint64_t steamID){
 	return "";
 }
 // Returns true if the friend is actually in game and fills in pFriendGameInfo with an extra details. 
-bool Steam::getFriendGamePlayed(uint64_t steamID){
+bool Steam::getFriendGamePlayed(uint64_t steamID, RefPtr gameInfo){
 	if(SteamFriends() == NULL){
+		//you have no friends :'c
 		return false;
 	}
-	FriendGameInfo_t gameInfo;
+	//parameters to pass into the steam api
 	CSteamID userID = (uint64)steamID;
-	bool isFriend = SteamFriends()->GetFriendGamePlayed(userID, &gameInfo);
+	FriendGameInfo_t gameInfoT;
+	//call the steamworks api function
+	bool isFriend = SteamFriends()->GetFriendGamePlayed(userID, &gameInfoT);
+	//make a nice little pocket of memory for the game info to sit in
+	Ref<FriendGameInfoRef> infoRefLocation(memnew(FriendGameInfoRef));
+	//copy data from our struct into our cozy little pocket of memory
+	infoRefLocation->gameInfo = gameInfoT;
+	//return pointer of new memory address to our gameInfo parameter
+	gameInfo = infoRefLocation.get_ref_ptr();
+
+	if(!gameInfoT.m_steamIDLobby.IsValid()) {return false;}//return false if lobby is not valid
+	
 	return isFriend;
 }
 // Accesses old friends names; returns an empty string when there are no more items in the history.
@@ -3016,7 +3028,7 @@ void Steam::_bind_methods(){
 	ClassDB::bind_method("getFriendRelationship", &Steam::getFriendRelationship);
 	ClassDB::bind_method("getFriendPersonaState", &Steam::getFriendPersonaState);
 	ClassDB::bind_method("getFriendPersonaName", &Steam::getFriendPersonaName);
-	ClassDB::bind_method("getFriendGamePlayed", &Steam::getFriendGamePlayed);
+	ClassDB::bind_method(D_METHOD("getFriendGamePlayed", "steamid", "gameinfo"), &Steam::getFriendGamePlayed);
 	ClassDB::bind_method("getFriendPersonaNameHistory", &Steam::getFriendPersonaNameHistory);
 	ClassDB::bind_method("getFriendSteamLevel", &Steam::getFriendSteamLevel);
 	ClassDB::bind_method("getPlayerNickname", &Steam::getPlayerNickname);

--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -522,7 +522,7 @@ bool Steam::getFriendGamePlayed(uint64_t steamID, RefPtr gameInfo){
 	//make a nice little pocket of memory for the game info to sit in
 	Ref<FriendGameInfoRef> infoRefLocation(memnew(FriendGameInfoRef));
 	//copy data from our struct into our cozy little pocket of memory
-	infoRefLocation->gameInfo = gameInfoT;
+	infoRefLocation->set_game_info(gameInfoT);
 	//return pointer of new memory address to our gameInfo parameter
 	gameInfo = infoRefLocation.get_ref_ptr();
 
@@ -2971,6 +2971,11 @@ Dictionary Steam::getItemDownloadInfo(int fileID){
 /////////////////////////////////////////////////
 ///// BIND METHODS //////////////////////////////
 //
+
+void FriendGameInfoRef::_bind_methods(){
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "game_info"), "set_game_info", "get_game_info");
+}
+
 void Steam::_bind_methods(){
 	ClassDB::bind_method("restartAppIfNecessary", &Steam::restartAppIfNecessary);
 	ClassDB::bind_method("steamInit", &Steam::steamInit);

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -9,6 +9,21 @@
 #include "core/reference.h"
 #include "core/dictionary.h"					// Contains array.h as well
 
+// Friend info //////////////////////////
+struct FriendGameInfo {
+	uint64_t gameID;
+	uint32 gameIP;
+	uint16 gamePort;
+	uint16 queryPort;
+	uint64_t steamIDLobby;
+};
+
+class FriendGameInfoRef: public Reference {
+	GDCLASS(FriendGameInfoRef, Reference);
+	public:
+		FriendGameInfo_t gameInfo;
+};
+
 class Steam: public Object {
 	GDCLASS(Steam, Object);
 	public:
@@ -120,7 +135,7 @@ class Steam: public Object {
 		int getFriendRelationship(uint64_t steamID);
 		int getFriendPersonaState(uint64_t steamID);
 		String getFriendPersonaName(uint64_t steamID);
-		bool getFriendGamePlayed(uint64_t steamID);
+		bool getFriendGamePlayed(uint64_t steamID, RefPtr gameInfo);
 		String getFriendPersonaNameHistory(uint64_t steamID, int nameHistory);
 		int getFriendSteamLevel(uint64_t steamID);
 		String getPlayerNickname(uint64_t steamID);
@@ -351,13 +366,6 @@ class Steam: public Object {
 		};
 		Vector<TicketData> tickets;
 		// Friend info //////////////////////////
-		struct FriendGameInfo {
-			uint64_t gameID;
-			uint32 gameIP;
-			uint16 gamePort;
-			uint16 queryPort;
-			uint64_t steamIDLobby;
-		};
 		Vector<FriendGameInfo> gameInfo;
 		// Friend session state info ////////////
 		struct FriendSessionStateInfo {

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -20,8 +20,16 @@ struct FriendGameInfo {
 
 class FriendGameInfoRef: public Reference {
 	GDCLASS(FriendGameInfoRef, Reference);
+	private:
+		FriendGameInfo_t game_info;
 	public:
-		FriendGameInfo_t gameInfo;
+		//setter and getter methods (overloaded)
+		//pointer versions of these could be added as well.
+		_FORCE_INLINE_ void set_game_info(const Ref<FriendGameInfoRef> &p_game_info) {game_info = p_game_info->game_info;}
+		_FORCE_INLINE_ void set_game_info(const FriendGameInfo_t p_game_info) {game_info = p_game_info;}
+		_FORCE_INLINE_ FriendGameInfo_t get_game_info() {return game_info;}
+	protected:
+		static void _bind_methods();
 };
 
 class Steam: public Object {

--- a/godotsteam/register_types.cpp
+++ b/godotsteam/register_types.cpp
@@ -6,6 +6,7 @@
 static Steam* SteamPtr = NULL;
 
 void register_godotsteam_types(){
+	ClassDB::register_class<FriendGameInfoRef>();
 	ClassDB::register_class<Steam>();
 	SteamPtr = memnew(Steam);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Steam",Steam::get_singleton()));


### PR DESCRIPTION
As mentioned over here:
https://github.com/Gramps/GodotSteam/issues/74
this is a necessary feature.

This pull request has my take on how to add this functionality.

at the moment when you call this function it causes this crash:
` drivers\unix\net_socket_posix.cpp:190 - Socket error: 10054`

so something is not quite right yet, but it is headed in the right direction I think.