### PR TITLE
extended friend game info functionality with closer-to-steamdocs code

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -535,6 +535,7 @@ Dictionary Steam::getFriendGamePlayedD(uint64_t steamID){
 			friendGame["gamePort"] = gameInfo.m_usGamePort;
 			friendGame["queryPort"] = (char)gameInfo.m_usQueryPort;
 			friendGame["lobby"] = uint64_t(gameInfo.m_steamIDLobby.ConvertToUint64());
+			friendGame["friendID"] = steamID;
 		}
 		else{
 			friendGame["error"] = "No valid lobby";
@@ -555,7 +556,7 @@ bool Steam::getFriendGamePlayed(uint64_t steamID, Ref<FriendGameInfo> friendGame
 	if(success) {// && gameInfo.m_steamIDLobby.IsValid()
 		//m_steamIDLobbyIsValid
 
-			Ref<FriendGameInfo> gameInfoObject = FriendGameInfo::new_from_struct(gameInfo);
+			Ref<FriendGameInfo> gameInfoObject = FriendGameInfo::new_from_struct(gameInfo, steamID);
 			friendGameInfo = &gameInfoObject;
 	}
 	return success;
@@ -3028,6 +3029,9 @@ void FriendGameInfo::_bind_methods(){
 
 	//set and gets
 
+	ClassDB::bind_method(D_METHOD("set_friendID", "_friendID"), &FriendGameInfo::set_friendID);
+	ClassDB::bind_method(D_METHOD("get_friendID"), &FriendGameInfo::get_friendID);
+
 	ClassDB::bind_method(D_METHOD("set_gameID", "_gameID"), &FriendGameInfo::set_gameID);
 	ClassDB::bind_method(D_METHOD("get_gameID"), &FriendGameInfo::get_gameID);
 
@@ -3711,8 +3715,9 @@ Dictionary FriendGameInfo::get_dictionary() {
 }
 
 //creates a new FriendGameInfo object from a filled FriendGameInfo_t struct
-Ref<FriendGameInfo> FriendGameInfo::new_from_struct(FriendGameInfo_t gameInfoStruct) {
+Ref<FriendGameInfo> FriendGameInfo::new_from_struct(FriendGameInfo_t gameInfoStruct, uint64_t _friendID) {
 	Ref<FriendGameInfo> newGameInfo(memnew(FriendGameInfo));
+	newGameInfo->set_friendID(_friendID);
 	newGameInfo->set_gameID(uint64_t(gameInfoStruct.m_gameID.ToUint64()));
 	newGameInfo->set_appID(uint32_t(gameInfoStruct.m_gameID.AppID()));
 	newGameInfo->set_gameIP(uint32_t(gameInfoStruct.m_unGameIP));

--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -3021,15 +3021,44 @@ Dictionary Steam::getItemDownloadInfo(int fileID){
 //
 
 void FriendGameInfo::_bind_methods(){
+	
+	//
+	//define properties so that godot likes us :)
+	//
+
+	//set and gets
+
+	ClassDB::bind_method(D_METHOD("set_gameID", "_gameID"), &FriendGameInfo::set_gameID);
+	ClassDB::bind_method(D_METHOD("get_gameID"), &FriendGameInfo::get_gameID);
+
+	ClassDB::bind_method(D_METHOD("set_appID", "_appID"), &FriendGameInfo::set_appID);
+	ClassDB::bind_method(D_METHOD("get_appID"), &FriendGameInfo::get_appID);
+
+	ClassDB::bind_method(D_METHOD("set_gameIP", "_gameIP"), &FriendGameInfo::set_gameIP);
+	ClassDB::bind_method(D_METHOD("get_gameIP"), &FriendGameInfo::get_gameIP);
+	ClassDB::bind_method(D_METHOD("get_gameIP_str"), &FriendGameInfo::get_gameIP_str);
+
+	ClassDB::bind_method(D_METHOD("set_gamePort", "_gamePort"), &FriendGameInfo::set_gamePort);
+	ClassDB::bind_method(D_METHOD("get_gamePort"), &FriendGameInfo::get_gamePort);
+
+	ClassDB::bind_method(D_METHOD("set_queryPort", "_queryPort"), &FriendGameInfo::set_queryPort);
+	ClassDB::bind_method(D_METHOD("get_queryPort"), &FriendGameInfo::get_queryPort);
+
+	ClassDB::bind_method(D_METHOD("set_steamIDLobby", "_steamIDLobby"), &FriendGameInfo::set_steamIDLobby);
+	ClassDB::bind_method(D_METHOD("get_steamIDLobby"), &FriendGameInfo::get_steamIDLobby);
+
+
+	//extra helper functions
+	ClassDB::bind_method(D_METHOD("get_dictionary"), &FriendGameInfo::get_dictionary);
+	ClassDB::bind_method(D_METHOD("m_steamIDLobbyIsValid"), &FriendGameInfo::m_steamIDLobbyIsValid);
+
+	//properties need the set and get methods registered so they get defined after the methods
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gameID"), "set_gameID", "get_gameID");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gameIP"), "set_gameIP", "get_gameIP");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "gamePort"), "set_gamePort", "get_gamePort");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "queryPort"), "set_queryPort", "get_queryPort");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "steamIDLobby"), "set_steamIDLobby", "get_steamIDLobby");
 
-	ClassDB::bind_method(D_METHOD("get_dictionary"), &FriendGameInfo::get_dictionary);
-	ClassDB::bind_method(D_METHOD("get_gameIP_str"), &FriendGameInfo::get_gameIP_str);
-	ClassDB::bind_method(D_METHOD("m_steamIDLobbyIsValid"), &FriendGameInfo::m_steamIDLobbyIsValid);
 
 	//ClassDB::bind_method(D_METHOD("new_from_struct", "gameInfoStruct"), &FriendGameInfo::get_dictionary);//probably shouldn't be bound
 }

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -14,6 +14,8 @@ class FriendGameInfo: public Reference {
 	GDCLASS(FriendGameInfo, Reference);
 	public:
 
+		uint64_t friendID;
+
 		uint64_t gameID;
 		uint32_t gameIP;
 		uint16_t gamePort;
@@ -29,6 +31,8 @@ class FriendGameInfo: public Reference {
 		//setter and getter methods
 		//
 
+		_FORCE_INLINE_ void set_friendID(uint64_t _friendID) {friendID = _friendID;}
+		_FORCE_INLINE_ uint64_t get_friendID()  {return friendID;}
 		_FORCE_INLINE_ void set_gameID(uint64_t _gameID) {gameID = _gameID;}
 		_FORCE_INLINE_ uint64_t get_gameID()  {return gameID;}
 		_FORCE_INLINE_ void set_appID(uint32_t _appID) {appID = _appID;}
@@ -67,7 +71,7 @@ class FriendGameInfo: public Reference {
 		Dictionary get_dictionary();
 		
 		//initializes a new Ref<FriendGameInfo> object from the received steam gameInfo struct
-		static Ref<FriendGameInfo> new_from_struct(FriendGameInfo_t gameInfoStruct);
+		static Ref<FriendGameInfo> new_from_struct(FriendGameInfo_t gameInfoStruct, uint64_t _friendID);
 
 	protected:
 		static void _bind_methods();

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -8,6 +8,70 @@
 #include "scene/resources/texture.h"	// For avatars
 #include "core/reference.h"
 #include "core/dictionary.h"					// Contains array.h as well
+#include "core/variant.h" //for returning several container types and Strings
+
+class FriendGameInfo: public Reference {
+	GDCLASS(FriendGameInfo, Reference);
+	public:
+
+		uint64_t gameID;
+		uint32_t gameIP;
+		uint16_t gamePort;
+		uint16_t queryPort;
+		uint64_t steamIDLobby;
+
+		uint32_t appID;
+
+		//keep a copy of the original struct so we don't have to attempt to convert back to use functionality
+		FriendGameInfo_t originalStruct;
+		
+		//
+		//setter and getter methods
+		//
+
+		_FORCE_INLINE_ void set_gameID(uint64_t _gameID) {gameID = _gameID;}
+		_FORCE_INLINE_ uint64_t get_gameID()  {return gameID;}
+		_FORCE_INLINE_ void set_appID(uint32_t _appID) {appID = _appID;}
+		_FORCE_INLINE_ uint32_t get_appID()  {return appID;}
+		_FORCE_INLINE_ void set_gameIP(uint32_t _gameIP)  {gameIP = _gameIP;}
+		_FORCE_INLINE_ uint32_t get_gameIP()  {return gameIP;}
+		_FORCE_INLINE_ String get_gameIP_str() {
+			// Convert the IP address back to a string
+			const int NBYTES = 4;
+			uint8 octet[NBYTES];
+			char gameIPstr[16];
+			for(int j = 0; j < NBYTES; j++){
+				octet[j] = gameIP >> (j * 8);
+			}
+			sprintf_s(gameIPstr, "%d.%d.%d.%d", octet[3], octet[2], octet[1], octet[0]);
+			//lets hope this uses the Godot string instead of steams string because stupid godot doesn't have a namespace for it
+			return String(gameIPstr);
+		}
+		_FORCE_INLINE_ void set_gamePort(uint16_t _gamePort) {gamePort = _gamePort;}
+		_FORCE_INLINE_ uint16_t get_gamePort()  {return gamePort;}
+		_FORCE_INLINE_ void set_queryPort(uint16_t _queryPort)  {queryPort = _queryPort;}
+		_FORCE_INLINE_ uint16_t get_queryPort()  {return queryPort;}
+		_FORCE_INLINE_ void set_steamIDLobby(uint64_t _steamIDLobby)  {steamIDLobby = _steamIDLobby;}
+		_FORCE_INLINE_ uint64_t get_steamIDLobby()  {return steamIDLobby;}
+		
+		_FORCE_INLINE_ FriendGameInfo_t get_struct() {return originalStruct;}//this may be needed later in order to use other steam functions with the struct behind the scenes
+		
+		//
+		//helper methods
+		//
+
+		//returns wether the lobby is valid same as gameInfo.m_steamIDLobby.IsValid()
+		_FORCE_INLINE_ bool m_steamIDLobbyIsValid() {return originalStruct.m_steamIDLobby.IsValid();}
+
+		//returns content as a dictionary
+		Dictionary get_dictionary();
+		
+		//initializes a new Ref<FriendGameInfo> object from the received steam gameInfo struct
+		static Ref<FriendGameInfo> new_from_struct(FriendGameInfo_t gameInfoStruct);
+
+	protected:
+		static void _bind_methods();
+};
 
 class Steam: public Object {
 	GDCLASS(Steam, Object);
@@ -121,7 +185,9 @@ class Steam: public Object {
 		int getFriendRelationship(uint64_t steamID);
 		int getFriendPersonaState(uint64_t steamID);
 		String getFriendPersonaName(uint64_t steamID);
-		Dictionary getFriendGamePlayed(uint64_t steamID);
+		Dictionary getFriendGamePlayedD(uint64_t steamID);
+		bool getFriendGamePlayed(uint64_t steamID, Ref<FriendGameInfo> friendGameInfo);
+		Array getFriendGameLobbies();
 		String getFriendPersonaNameHistory(uint64_t steamID, int nameHistory);
 		int getFriendSteamLevel(uint64_t steamID);
 		String getPlayerNickname(uint64_t steamID);

--- a/godotsteam/register_types.cpp
+++ b/godotsteam/register_types.cpp
@@ -6,6 +6,7 @@
 static Steam* SteamPtr = NULL;
 
 void register_godotsteam_types(){
+	ClassDB::register_class<FriendGameInfo>();
 	ClassDB::register_class<Steam>();
 	SteamPtr = memnew(Steam);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Steam",Steam::get_singleton()));


### PR DESCRIPTION
extended friend game info functionality with closer-to-steamdocs code with some helper methods and a shortcut for the common getFriendGameLobbies so that getFriendGamePlayed can be used just like the original function and getFriendGameLobbies can be used to get an array of all the game lobbies for you built in already. Left in the original dictionary method as well for options / compatibility sake as well as a method to return a dictionary from the class object if someone prefers the dictionary.

Compiles 👍
I am testing it as we speak :)

Let me know if there was any point to this. I think it is quite useful personally.

EDIT: now getting lobbies is a one liner: `var lobbies = Steam.getFriendGameLobbies()`
EDIT2:
![:D](https://i.gyazo.com/e81607d7145af47f4fa9598e28df83dc.png)
EDIT3: it isn't crashing so that's good.