### PR TITLE
fix(complire): add osx compiler flag to use c++11

### DIFF
--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -30,5 +30,6 @@ def configure(env):
         env.Append(LIBS=["steam_api64"])
         env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/win64"])
   elif env["platform"] == "osx":
+    env.Append(CXXFLAGS="-std=c++0x")
     env.Append(LIBS=["steam_api"])
     env.Append(LIBPATH=['#modules/godotsteam/sdk/redistributable_bin/osx32'])


### PR DESCRIPTION
Add a flag for the c++ compiler in osx tu use C++11, which is requried to compile `nullptr`. Withous this, the build process fails because MacOS uses the default g++ version, which is 10.

:point_right:  This should be applied to all version branches.