### PR TITLE
Friend relationship for lobby owner + OSX build fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -104,6 +104,8 @@ if target_platform == 'osx':
 	env.Append(RPATH=env.Literal("\\$$ORIGIN"))
 	# Set correct Steam library
 	steam_lib_path += "/osx32"
+	# Attach the CPP bindings lib
+	env.Append(LIBS = [ 'libgodot-cpp.' + target_platform + '.' + target_arch + '.a' ])
 # Append the last paths
 env.Append(CPPPATH = [ '.', 'src', 'include', godot_headers, cpp_bindings + '/include', cpp_bindings + '/include/core', 'include/sdk/public' ])
 env.Append(LIBS = [ steam_lib ])

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -1281,9 +1281,9 @@ void Steam::_lobby_match_list(LobbyMatchList_t *pCallback, bool bIOFailure) {
 	{
 		CSteamID steamIDLobby = SteamMatchmaking()->GetLobbyByIndex(iLobby);
 		uint64_t lobbyID = (uint64_t) steamIDLobby.ConvertToUint64();
-		CSteamID steamIDLobbyOwner = SteamMatchmaking()->GetLobbyOwner(lobbyID);
+		CSteamID steamIDLobbyOwner = SteamMatchmaking()->GetLobbyOwner(steamIDLobby);
 		uint64_t lobbyOwnerID = (uint64_t) steamIDLobbyOwner.ConvertToUint64();
-		int friendRelationship = SteamFriends()->GetFriendRelationship(steamIDLobbyOwner);
+		int friendRelationship = (int) SteamFriends()->GetFriendRelationship(steamIDLobbyOwner);
 		Dictionary entryDict;
 		entryDict["steamIDLobby"] = lobbyID;
 		entryDict["steamIDLobbyOwner"] = lobbyOwnerID;

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -1347,7 +1347,7 @@ void Steam::_avatar_loaded(AvatarImageLoaded_t* avatarData){
 }
 // Signal number of current players (online + offline).
 void Steam::_number_of_current_players(NumberOfCurrentPlayers_t *callData, bool bIOFailure){
-	owner->emit_signal("number_of_current_players", callData->m_bSuccess && bIOFailure, callData->m_cPlayers);
+	owner->emit_signal("number_of_current_players", callData->m_bSuccess && !bIOFailure, callData->m_cPlayers);
 }
 // Signal a leaderboard has been loaded or has failed.
 void Steam::_leaderboard_loaded(LeaderboardFindResult_t *callData, bool bIOFailure){
@@ -1361,7 +1361,7 @@ void Steam::_leaderboard_uploaded(LeaderboardScoreUploaded_t *callData, bool bIO
 	if(callData->m_hSteamLeaderboard != leaderboard_handle){
 		return;
 	}
-	owner->emit_signal("leaderboard_uploaded", callData->m_bSuccess && bIOFailure, callData->m_nScore, callData->m_bScoreChanged, callData->m_nGlobalRankNew, callData->m_nGlobalRankPrevious);
+	owner->emit_signal("leaderboard_uploaded", callData->m_bSuccess && !bIOFailure, callData->m_nScore, callData->m_bScoreChanged, callData->m_nGlobalRankNew, callData->m_nGlobalRankPrevious);
 }
 // Signal leaderboard entries are downloaded.
 void Steam::_leaderboard_entries_loaded(LeaderboardScoresDownloaded_t *callData, bool bIOFailure){

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -1281,8 +1281,13 @@ void Steam::_lobby_match_list(LobbyMatchList_t *pCallback, bool bIOFailure) {
 	{
 		CSteamID steamIDLobby = SteamMatchmaking()->GetLobbyByIndex(iLobby);
 		uint64_t lobbyID = (uint64_t) steamIDLobby.ConvertToUint64();
+		CSteamID steamIDLobbyOwner = SteamMatchmaking()->GetLobbyOwner(lobbyID);
+		uint64_t lobbyOwnerID = (uint64_t) steamIDLobbyOwner.ConvertToUint64();
+		int friendRelationship = SteamFriends()->GetFriendRelationship(steamIDLobbyOwner);
 		Dictionary entryDict;
 		entryDict["steamIDLobby"] = lobbyID;
+		entryDict["steamIDLobbyOwner"] = lobbyOwnerID;
+		entryDict["friendRelationship"] = friendRelationship;
 		listLobbies.append(entryDict);
 	}
 	owner->emit_signal("lobby_match_list");

--- a/src/godotsteam.cpp
+++ b/src/godotsteam.cpp
@@ -1281,13 +1281,8 @@ void Steam::_lobby_match_list(LobbyMatchList_t *pCallback, bool bIOFailure) {
 	{
 		CSteamID steamIDLobby = SteamMatchmaking()->GetLobbyByIndex(iLobby);
 		uint64_t lobbyID = (uint64_t) steamIDLobby.ConvertToUint64();
-		CSteamID steamIDLobbyOwner = SteamMatchmaking()->GetLobbyOwner(steamIDLobby);
-		uint64_t lobbyOwnerID = (uint64_t) steamIDLobbyOwner.ConvertToUint64();
-		int friendRelationship = (int) SteamFriends()->GetFriendRelationship(steamIDLobbyOwner);
 		Dictionary entryDict;
 		entryDict["steamIDLobby"] = lobbyID;
-		entryDict["steamIDLobbyOwner"] = lobbyOwnerID;
-		entryDict["friendRelationship"] = friendRelationship;
 		listLobbies.append(entryDict);
 	}
 	owner->emit_signal("lobby_match_list");


### PR DESCRIPTION
Two small commits to improve GodotSteam experience :)
1) I've added lobby owner ID and friend relationship of lobby owner with the current user.
Using this information we can filter lobbies later in code (to show, for example, lobbies only created by friends of the current user or filter out lobbies created by someone who is on blacklist and so on)
2) Small fix in SConstruct file, without that the library crashes on start (I've copied this from Linux part of the build file and it helped)
3) Small fix for success parameter for some signals: due to misprint there is no ! sign, therefore the value of the parameter was wrong. I heard that this was fixed in the master branch, but it looks like it was not fixed in the gdnative branch.