### PR TITLE
[macos] Fix nullptr issue during compilation.

### DIFF
--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -30,5 +30,6 @@ def configure(env):
         env.Append(LIBS=["steam_api64"])
         env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/win64"])
   elif env["platform"] == "osx":
+    env.Append(CXXFLAGS="-std=c++0x")
     env.Append(LIBS=["steam_api"])
     env.Append(LIBPATH=['#modules/godotsteam/sdk/redistributable_bin/osx32'])


### PR DESCRIPTION
Added a macos compiler flag to fix a nullptr issue during compilation, full credit to @guillem-sopra

This has already been fixed for the godot2 branch but for some reason was not yet added to the godot3 branch.