### PR TITLE
Rename sdk/redistributable_bin/osx32 to sdk/redistributable_bin/osx

### DIFF
--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -37,4 +37,4 @@ def configure(env):
 	elif env["platform"] == "osx":
 		env.Append(CXXFLAGS="-std=c++0x")
 		env.Append(LIBS=["steam_api"])
-		env.Append(LIBPATH=['#modules/godotsteam/sdk/redistributable_bin/osx32'])
+		env.Append(LIBPATH=['#modules/godotsteam/sdk/redistributable_bin/osx'])


### PR DESCRIPTION
Fixes #105 

Today when compiling against Steamworks SDK `v1.46`, I encountered a link error and
figured out that Steamworks SDK actually renamed `sdk/redistributable_bin/osx32` to `sdk/redistributable_bin/osx`.

Using this version, I was able to successfuly compile against `v1.46`