### PR TITLE
remove unnecessary newline breaking expected text in patch script

### DIFF
--- a/godotsteam/mingw_patch.py
+++ b/godotsteam/mingw_patch.py
@@ -50,7 +50,7 @@ def check_if_in_godot_steam():
 def main():
     result = ''
     with open(isteamuser_path, 'r') as file:
-        top, include, rest = file.read().partition('#include "steam_api_common.h"\n')
+        top, include, rest = file.read().partition('#include "steam_api_common.h"')
         result = ''.join((
             top,
             include,


### PR DESCRIPTION
- brought up in #120 
- pending approval/testing from @zombieCraig
- remove newline that I thought was normalized by python and blocked correct behavior in windows