### PR TITLE
Use String::utf8 instead of charToWChar in getQueryUGCResult

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -5001,13 +5001,6 @@ String Steam::getQueryUGCPreviewURL(uint64_t queryHandle, uint32 index){
 	return "";
 }
 
-static wchar_t *charToWChar(const char *text) {
-	size_t size = strlen(text) + 1;
-	wchar_t *wa = new wchar_t[size];
-	mbstowcs(wa, text, size);
-	return wa;
-}
-
 // Retrieve the details of an individual workshop item after receiving a querying UGC call result.
 Dictionary Steam::getQueryUGCResult(uint64_t queryHandle, uint32 index){
 	Dictionary ugcResult;
@@ -5023,8 +5016,8 @@ Dictionary Steam::getQueryUGCResult(uint64_t queryHandle, uint32 index){
 		ugcResult["fileType"] = (uint64_t)pDetails.m_eFileType;
 		ugcResult["creatorAppID"] = (uint64_t)pDetails.m_nCreatorAppID;
 		ugcResult["consumerAppID"] = (uint64_t)pDetails.m_nConsumerAppID;
-		ugcResult["title"] = charToWChar(pDetails.m_rgchTitle);
-		ugcResult["description"] = charToWChar(pDetails.m_rgchDescription);
+		ugcResult["title"] = String::utf8(pDetails.m_rgchTitle);
+		ugcResult["description"] = String::utf8(pDetails.m_rgchDescription);
 		ugcResult["steamIDOwner"] = (uint64_t)pDetails.m_ulSteamIDOwner;
 		ugcResult["timeCreated"] = pDetails.m_rtimeCreated;
 		ugcResult["timeUpdated"] = pDetails.m_rtimeUpdated;


### PR DESCRIPTION
I realised that String::utf8 exists, this seems to work fine on Windows unlike the previous solution.