### PR TITLE
Fix to setAchievement return statement

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -6869,8 +6869,8 @@ bool Steam::setAchievement(const String& name){
 	if(SteamUserStats() == NULL){
 		return 0;
 	}
-	SteamUserStats()->SetAchievement(name.utf8().get_data());
-	return SteamUserStats()->StoreStats();
+	bool ach_set = SteamUserStats()->SetAchievement(name.utf8().get_data());
+	return SteamUserStats()->StoreStats() && ach_set;
 }
 
 // Set a float statistic.


### PR DESCRIPTION
I noticed that the setAchievement function wouldn't actually return false if an achievement name that doesn't exist within the App Admin was passed in. This commit changes that so the function will return false in that scenario just as it would in the Steam API.