### PR TITLE
Fixed docs using user_stats_stored in place of current_stats_received

### DIFF
--- a/godotsteam/doc_classes/Steam.xml
+++ b/godotsteam/doc_classes/Steam.xml
@@ -477,7 +477,7 @@
 			<argument index="0" name="achievementName" type="String">
 			</argument>
 			<description>
-				Reverts the unlock status of the specified achievement. This is primarily used for testing. This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [method storeStats]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Reverts the unlock status of the specified achievement. This is primarily used for testing. This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [method storeStats]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns [code]true[/code] if clearing the achievement was executed successful.
 			</description>
 		</method>
@@ -1171,7 +1171,7 @@
 			<argument index="0" name="achievementName" type="String">
 			</argument>
 			<description>
-				Gets if and when the specified achievement was unlocked. If the specified achievement was unlocked but it's unlock time is zero, that means it was unlocked before Steam began tracking achievement unlock times (December 2009). To check the achievement status for a different user use [method getUserAchievementAndUnlockTime]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets if and when the specified achievement was unlocked. If the specified achievement was unlocked but it's unlock time is zero, that means it was unlocked before Steam began tracking achievement unlock times (December 2009). To check the achievement status for a different user use [method getUserAchievementAndUnlockTime]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns a Dictionary with three entries. The key [code]ret[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the call was made successfully. The key [code]achieved[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the specified achievement has been unlocked by the user. The key [code]unlocked[/code] in the Dictionary is mapped to an int containing the unlock time of the specified achievement in seconds since January 1, 1970 UTC.
 			</description>
 		</method>
@@ -1183,7 +1183,7 @@
 			<argument index="1" name="key" type="String">
 			</argument>
 			<description>
-				Gets the general attributes for the specified achievement. Currently provides: Name, Description, and Hidden status. The localization is provided based on the game's language if it's set, otherwise it checks if a localization is available from the user's Steam UI Language. If that fails too, then it falls back to english. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets the general attributes for the specified achievement. Currently provides: Name, Description, and Hidden status. The localization is provided based on the game's language if it's set, otherwise it checks if a localization is available from the user's Steam UI Language. If that fails too, then it falls back to english. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns the name of the specified achievement if [code]key[/code] is set to [code]"name"[/code], the description of the specified achievement if [code]key[/code] is set to [code]"desc"[/code], or the hidden state of the specified achievement if [code]key[/code] is set to [code]"hidden"[/code] ([code]"0"[/code] for shown and [code]"1"[/code] for hidden.) The function will also return an empty string if [method requestCurrentStats] did not return it's callback successfully, the specified achievement does not exist within the App Admin, or the specified key is invalid.
 			</description>
 		</method>
@@ -1193,7 +1193,7 @@
 			<argument index="0" name="achievementName" type="String">
 			</argument>
 			<description>
-				Gets the icon of the specified achievement. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets the icon of the specified achievement. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns an int as a handle to be used with [method getImageRGBA] to get the actual image data. An invalid handle of 0 will be returned if [method requestCurrentStats] has not completed or has not successfully returned its callback, the specified achievement was not found in the App Admin, or Steam is still fetching the image data from the server.
 				Example: [br][code]var image_handle:int = Steam.getAchievementIcon("achievement_api_name")
 				var image_dict:Dictionary = Steam.getImageRGBA(image_handle)
@@ -1210,7 +1210,7 @@
 			<argument index="0" name="achievementIndex" type="int">
 			</argument>
 			<description>
-				Gets the 'API name' for an achievement by it's index between 0 and [method getNumAchievements]. This function must be used in conjunction with [method getNumAchievements] to loop over the list of achievements. In general, games should not need these functions as they should have the list of achievements compiled into them. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets the 'API name' for an achievement by it's index between 0 and [method getNumAchievements]. This function must be used in conjunction with [method getNumAchievements] to loop over the list of achievements. In general, games should not need these functions as they should have the list of achievements compiled into them. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns the 'API Name' of the achievement; otherwise returns an empty string if [code]achievementIndex[/code] is not a valid index.
 			</description>
 		</method>
@@ -2198,7 +2198,7 @@
 			<return type="int">
 			</return>
 			<description>
-				Get the number of achievements defined in the App Admin panel of the Steamworks website. This is used for iterating through all of the achievements with [method getAchievementName]. In general games should not need these functions because they should have a list of existing achievements compiled into them. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Get the number of achievements defined in the App Admin panel of the Steamworks website. This is used for iterating through all of the achievements with [method getAchievementName]. In general games should not need these functions because they should have a list of existing achievements compiled into them. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns the number of achievements defined in the App Admin; otherwise returns 0 if [method requestCurrentStats] has not been called or has not been successfully called.
 			</description>
 		</method>
@@ -2638,7 +2638,7 @@
 			<argument index="1" name="achievementName" type="String">
 			</argument>
 			<description>
-				Gets whether or not the specified achievement has been unlocked by the specified user. To check the achievement status of the local user use [method getAchievement]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets whether or not the specified achievement has been unlocked by the specified user. To check the achievement status of the local user use [method getAchievement]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns a Dictionary with four entries. The key [code]retrieved[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the call was made successfully. The key [code]achieved[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the specified achievement has been unlocked by the specified user. The key [code]name[/code] in the Dictionary is mapped to a String containing the api name of the achievement (aka [code]achievementName[/code]). The key [code]steam_id[/code] in the Dictionary is mapped to an int containing the user's steam id.
 			</description>
 		</method>
@@ -2650,7 +2650,7 @@
 			<argument index="1" name="achievementName" type="String">
 			</argument>
 			<description>
-				Gets if and when the specified achievement was unlocked by the specified user. If the specified achievement was unlocked but it's unlock time is zero, that means it was unlocked before Steam began tracking achievement unlock times (December 2009). To check the achievement status for the local user use [method getAchievementAndUnlockTime]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Gets if and when the specified achievement was unlocked by the specified user. If the specified achievement was unlocked but it's unlock time is zero, that means it was unlocked before Steam began tracking achievement unlock times (December 2009). To check the achievement status for the local user use [method getAchievementAndUnlockTime]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns a Dictionary with three entries. The key [code]retrieved[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the call was made successfully. The key [code]achieved[/code] in the Dictionary is mapped to a boolean that is [code]true[/code] if the specified achievement has been unlocked by the user. The key [code]unlocked[/code] in the Dictionary is mapped to an int containing the unlock time of the specified achievement in seconds since January 1, 1970 UTC. The key [code]name[/code] in the Dictionary is mapped to a String containing the api name of the achievement (aka [code]achievementName[/code]).
 			</description>
 		</method>
@@ -2790,7 +2790,7 @@
 			<argument index="2" name="targetProgress" type="int">
 			</argument>
 			<description>
-				Shows the user a pop-up notification with the current progress of the specified achievement. Calling this function will NOT set the progress or unlock the achievement, the game must do that manually by calling [method setStatInt] or [method setStatFloat]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Shows the user a pop-up notification with the current progress of the specified achievement. Calling this function will NOT set the progress or unlock the achievement, the game must do that manually by calling [method setStatInt] or [method setStatFloat]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				Returns [code]true[/code] if [method requestCurrentStats] has been successfully called, the specified achievement is found in the App Admin, and the specified achievement isn't already unlocked; otherwise returns [code]false[/code].
 			</description>
 		</method>
@@ -3596,7 +3596,7 @@
 			<return type="void">
 			</return>
 			<description>
-				Asynchronously fetches the data for the percentage of players who have received each achievement for the current game, globally. Emits [signal global_achievement_percentages_ready] when the results have been received. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted.
+				Asynchronously fetches the data for the percentage of players who have received each achievement for the current game, globally. Emits [signal global_achievement_percentages_ready] when the results have been received. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted.
 				See also: [method getMostAchievedAchievementInfo] and [method getAchievementAchievedPercent]
 			</description>
 		</method>
@@ -3842,7 +3842,7 @@
 			<argument index="0" name="achievementName" type="String">
 			</argument>
 			<description>
-				Unlocks the the specified achievement. This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [method storeStats]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal user_stats_stored] must have been emitted. 
+				Unlocks the the specified achievement. This call only modifies Steam's in-memory state so it is quite cheap. To send the unlock status to the server and to trigger the Steam overlay notification you must call [method storeStats]. Before calling this function, [method requestCurrentStats] must have been called ([method steamInit] does this automatically by default.) and it’s callback signal [signal current_stats_received] must have been emitted. 
 				Returns [code]true[/code] if the specified achievement has been unlocked successfully; otherwise returns [code]false[/code] if [code]achievementName[/code] is not a valid achievement api name.
 			</description>
 		</method>


### PR DESCRIPTION
The new docs for the achievement functions incorrectly identified
user_stats_stored as the callback for requestCurrentStats. This has been
corrected to use current_stats_received.