### PR TITLE
Allow building with 'scons custom_modules=...'

### DIFF
--- a/godotsteam/SCsub
+++ b/godotsteam/SCsub
@@ -2,4 +2,43 @@
 # SCsub
 Import('env')
 
+module_path = Dir('.').srcnode().abspath
+
+env.Append(CPPPATH=["%s/sdk/public/" % module_path])
+
+# If compiling Linux
+if env["platform"]== "x11" or env["platform"] == "server":
+	env.Append(LIBS=["steam_api"])
+	env.Append(RPATH=["."])
+	if env["bits"]=="32":
+		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux32" % module_path])
+	else: # 64 bit
+		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux64" % module_path])
+
+# If compiling Windows
+elif env["platform"] == "windows":
+	# Mostly VisualStudio
+	if env["CC"] == "cl":
+		if env["bits"]=="32":
+			env.Append(LINKFLAGS=["steam_api.lib"])
+			env.Append(LIBPATH=["%s/sdk/redistributable_bin" % module_path])
+		else: # 64 bit
+			env.Append(LINKFLAGS=["steam_api64.lib"])
+			env.Append(LIBPATH=["%s/sdk/redistributable_bin/win64" % module_path])
+	
+	# Mostly "GCC"
+	else:
+		if env["bits"]=="32":
+			env.Append(LIBS=["steam_api"])
+			env.Append(LIBPATH=["%s/sdk/redistributable_bin" % module_path])
+		else: # 64 bit
+			env.Append(LIBS=["steam_api64"])
+			env.Append(LIBPATH=["%s/sdk/redistributable_bin/win64" % module_path])
+
+# If compiling OSX
+elif env["platform"] == "osx":
+	env.Append(LIBS=["steam_api"])
+	env.Append(LIBPATH=['%s/sdk/redistributable_bin/osx' % module_path])
+
 env.add_source_files(env.modules_sources,"*.cpp")
+

--- a/godotsteam/config.py
+++ b/godotsteam/config.py
@@ -2,41 +2,7 @@ def can_build(env, platform):
 	return platform=="x11" or platform=="windows" or platform=="osx" or platform=="server"
 
 def configure(env):
-	env.Append(CPPPATH=["#modules/godotsteam/sdk/public/"])
-
-	# If compiling Linux
-	if env["platform"]== "x11" or env["platform"] == "server":
-		env.Append(LIBS=["steam_api"])
-		env.Append(RPATH=["."])
-		if env["bits"]=="32":
-			env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/linux32"])
-		else: # 64 bit
-			env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/linux64"])
-
-	# If compiling Windows
-	elif env["platform"] == "windows":
-		# Mostly VisualStudio
-		if env["CC"] == "cl":
-			if env["bits"]=="32":
-				env.Append(LINKFLAGS=["steam_api.lib"])
-				env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin"])
-			else: # 64 bit
-				env.Append(LINKFLAGS=["steam_api64.lib"])
-				env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/win64"])
-		
-		# Mostly "GCC"
-		else:
-			if env["bits"]=="32":
-				env.Append(LIBS=["steam_api"])
-				env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin"])
-			else: # 64 bit
-				env.Append(LIBS=["steam_api64"])
-				env.Append(LIBPATH=["#modules/godotsteam/sdk/redistributable_bin/win64"])
-
-	# If compiling OSX
-	elif env["platform"] == "osx":
-		env.Append(LIBS=["steam_api"])
-		env.Append(LIBPATH=['#modules/godotsteam/sdk/redistributable_bin/osx'])
+	pass
 
 def get_doc_classes():
 	return [


### PR DESCRIPTION
I've started moving the modules that I use in Godot projects to be in the source code (and Git repo) for the game project itself (for example, in a `godot-modules/` directory), and then building Godot like `scons custom_modules=.../my-game-project/godot-modules`.

This is nice for keeping things organized: I have all the source for all the modules my games depend on in my game's source code, including any custom modules that I made for that game. It has also allowed me to setup CI to build Godot for games that need custom modules.

Anyway, for most modules, this just works! However, with GodotSteam, it doesn't, because it's using paths relative to the Godot source directory (ie. `env.Append(CPPPATH=["#modules/godotsteam/sdk/public/"])` with the `'#'` at the front of the path) to find the Steamworks SDK files.

This PR allows building GodotSteam both inside the Godot source tree, or outside of it using `scons custom_modules='...'`.

I've tested it on Linux and Windows.
