### PR TITLE
Fixes networking messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 doxygen/
+**/.DS_Store

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -934,7 +934,7 @@ class Steam: public Object {
 		bool closeSessionWithUser(const String& identity_reference);
 		Dictionary getSessionConnectionInfo(const String& identity_reference, bool get_connection, bool get_status);
 		Array receiveMessagesOnChannel(int channel, int max_messages);
-		int sendMessageToUser(const String& identity_reference, const String& message, int flags, int channel);
+		int sendMessageToUser(const String& identity_reference, const PoolByteArray data, int flags, int channel);
 		
 		// Networking Sockets ///////////////////
 		int acceptConnection(uint32 connection);


### PR DESCRIPTION
These fixes are not currently working, but I can't figure out why. Looking for help, keep reading for details.

Changes:
- Fixes "identity" and "ip_address" strings not being properly allocated in a variety of methods (also fixed in the other open PR)
- Fixes how received messages were being allocated, freed and iterated through (e.g. it was skipping the first message)
- Makes receiveMessagesOnChannel populate the payload as a PoolByteArray (which becomes a byte[]) instead of as a void* (which becomes a boolean)
- Makes sendMessageToUser accept a PoolByteArray instead of a string (simpler to implement for me, and more flexibility for the caller)

Bug that I haven't fixed:
receiveMessagesOnChannel will sometimes crash with an error that looks like its trying to dereference a null pointer on the `channel_messages[i].Release();` line.

```
Crashed Thread:        0  MainThrd  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGABRT)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

VM Region Info: 0 is not in any region.  Bytes before following region: 4395524096
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                      105fe6000-10b5c2000    [ 85.9M] r-x/r-x SM=COW  ...tools.64.mono

Application Specific Information:
abort() called


Thread 0 Crashed:: MainThrd Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	    0x7ff80eab300e __pthread_kill + 10
1   libsystem_pthread.dylib       	    0x7ff80eae91ff pthread_kill + 263
2   libsystem_c.dylib             	    0x7ff80ea34d24 abort + 123
3   libmonosgen-2.0.1.dylib       	       0x110b15aee mono_post_native_crash_handler + 14 (mini-posix.c:1168)
4   libmonosgen-2.0.1.dylib       	       0x110aad4d4 mono_handle_native_crash + 468 (mini-exceptions.c:3437)
5   libmonosgen-2.0.1.dylib       	       0x110b0f806 altstack_handle_and_restore + 230 (exceptions-amd64.c:879)
6   ???                           	               0x0 ???
7   godot.osx.tools.64.mono       	       0x106bff394 Steam::receiveMessagesOnChannel(int, int) + 1924 (godotsteam.cpp:4729)
8   godot.osx.tools.64.mono       	       0x106d3dbf8 MethodBind2R<Array, int, int>::ptrcall(Object*, void const**, void*) + 168 (method_bind.gen.inc:1724)
9   godot.osx.tools.64.mono       	       0x106ec9bee godot_icall_2_80(MethodBind*, Object*, int, int) + 222 (mono_glue.gen.cpp:769)
10  ???                           	       0x14a986a3a ???
```

Note that godotsteam.cpp:4729 in my stack trace corresponds to godotsteam.cpp:4856 in this PR.

Testing setup:
I am trying to get multiplayer working with a Windows and a Mac. I am programming my Godot game in C# (hence the mono references in the stack trace). I previously got the multiplayer working using the deprecated P2P API. I am trying to convert to the new Network Messages API, but ran into some problems, which this PR is designed to address. It's been awhile since I've programmed in C++, and I was never very good at it, so I'm at a loss for how to fix this error.

My testing setup looks something like this:
1. Get the two copies of the game running, one on Windows and one on Mac
2. Tell the Mac to send heartbeats to the Windows
3. Tell the Windows to send heartbeats to the Mac
4. The Windows receives the Mac's heartbeat and processes it successfully (include deserializing the JSON message body)
5. The Mac crashes trying to process the Window's heartbeat with the above error

Reversing the roles of the Windows and Mac in the test gives the same result, but with reversed outcome. So the Mac processes the heartbeat successfully and the Windows crashes.