### PR TITLE
Fix receive message functions

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -4919,38 +4919,39 @@ Array Steam::receiveMessagesOnChannel(int channel, int max_messages){
 	Array messages;
 	if(SteamNetworkingMessages() != NULL){
 		// Allocate the space for the messages
-		SteamNetworkingMessage_t *channel_messages;
+		SteamNetworkingMessage_t** channel_messages = new SteamNetworkingMessage_t*[max_messages];
 		// Get the messages
-		int available_messages = SteamNetworkingMessages()->ReceiveMessagesOnChannel(channel, &channel_messages, max_messages);
+		int available_messages = SteamNetworkingMessages()->ReceiveMessagesOnChannel(channel, channel_messages, max_messages);
 		// Loop through and create the messages as dictionaries then add to the messages array
 		for(int i = 0; i < available_messages; i++){
 			// Set up the mesage dictionary
 			Dictionary message;
 			// Get the data / message
-			int message_size = channel_messages[i].m_cbSize;
+			int message_size = channel_messages[i]->m_cbSize;
 			PoolByteArray data;
 			data.resize(message_size);
-			uint8_t* source_data = (uint8_t*)channel_messages[i].m_pData;
+			uint8_t* source_data = (uint8_t*)channel_messages[i]->m_pData;
 			uint8_t* output_data = data.write().ptr();
 			for(int j = 0; j < message_size; j++){
 				output_data[j] = source_data[j];
 			}
 			message["payload"] = data;
 			message["size"] = message_size;
-			message["connection"] = channel_messages[i].m_conn;
+			message["connection"] = channel_messages[i]->m_conn;
 			char identity[STEAM_BUFFER_SIZE];
-			channel_messages[i].m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
+			channel_messages[i]->m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
 			message["identity"] = identity;
-			message["user_data"] = (uint64_t)channel_messages[i].m_nConnUserData;
-			message["time_received"] = (uint64_t)channel_messages[i].m_usecTimeReceived;
-			message["message_number"] = (uint64_t)channel_messages[i].m_nMessageNumber;
-			message["channel"] = channel_messages[i].m_nChannel;
-			message["flags"] = channel_messages[i].m_nFlags;
-			message["user_data"] = (uint64_t)channel_messages[i].m_nUserData;
+			message["user_data"] = (uint64_t)channel_messages[i]->m_nConnUserData;
+			message["time_received"] = (uint64_t)channel_messages[i]->m_usecTimeReceived;
+			message["message_number"] = (uint64_t)channel_messages[i]->m_nMessageNumber;
+			message["channel"] = channel_messages[i]->m_nChannel;
+			message["flags"] = channel_messages[i]->m_nFlags;
+			message["user_data"] = (uint64_t)channel_messages[i]->m_nUserData;
 			messages.append(message);
 			// Release the message
-			channel_messages[i].Release();
+			channel_messages[i]->Release();
 		}
+		delete [] channel_messages;
 	}
 	return messages;
 }
@@ -5091,38 +5092,39 @@ Array Steam::receiveMessagesOnConnection(uint32 connection_handle, int max_messa
 	Array messages;
 	if(SteamNetworkingSockets() != NULL){
 		// Allocate the space for the messages
-		SteamNetworkingMessage_t *connection_messages;
+		SteamNetworkingMessage_t** connection_messages = new SteamNetworkingMessage_t*[max_messages];
 		// Get the messages
-		int available_messages = SteamNetworkingSockets()->ReceiveMessagesOnConnection((HSteamNetConnection)connection_handle, &connection_messages, max_messages);
+		int available_messages = SteamNetworkingSockets()->ReceiveMessagesOnConnection((HSteamNetConnection)connection_handle, connection_messages, max_messages);
 		// Loop through and create the messages as dictionaries then add to the messages array
 		for(int i = 0; i < available_messages; i++){
 			// Create the message dictionary to send back
 			Dictionary message;
 			// Get the message data
-			int message_size = connection_messages[i].m_cbSize;
+			int message_size = connection_messages[i]->m_cbSize;
 			PoolByteArray data;
 			data.resize(message_size);
-			uint8_t* source_data = (uint8_t*)connection_messages[i].m_pData;
+			uint8_t* source_data = (uint8_t*)connection_messages[i]->m_pData;
 			uint8_t* output_data = data.write().ptr();
 			for(int j = 0; j < message_size; j++){
 				output_data[j] = source_data[j];
 			}
 			message["payload"] = data;
 			message["size"] = message_size;
-			message["connection"] = connection_messages[i].m_conn;
+			message["connection"] = connection_messages[i]->m_conn;
 			char identity[STEAM_BUFFER_SIZE];
-			connection_messages[i].m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
+			connection_messages[i]->m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
 			message["identity"] = identity;
-			message["user_data"] = (uint64_t)connection_messages[i].m_nConnUserData;
-			message["time_received"] = (uint64_t)connection_messages[i].m_usecTimeReceived;
-			message["message_number"] = (uint64_t)connection_messages[i].m_nMessageNumber;
-			message["channel"] = connection_messages[i].m_nChannel;
-			message["flags"] = connection_messages[i].m_nFlags;
-			message["user_data"] = (uint64_t)connection_messages[i].m_nUserData;
+			message["user_data"] = (uint64_t)connection_messages[i]->m_nConnUserData;
+			message["time_received"] = (uint64_t)connection_messages[i]->m_usecTimeReceived;
+			message["message_number"] = (uint64_t)connection_messages[i]->m_nMessageNumber;
+			message["channel"] = connection_messages[i]->m_nChannel;
+			message["flags"] = connection_messages[i]->m_nFlags;
+			message["user_data"] = (uint64_t)connection_messages[i]->m_nUserData;
 			messages.append(message);
 			// Release the message
-			connection_messages[i].Release();
+			connection_messages[i]->Release();
 		}
+		delete [] connection_messages;
 	}
 	return messages;
 }
@@ -5156,38 +5158,39 @@ Array Steam::receiveMessagesOnPollGroup(uint32 poll_group, int max_messages){
 	Array messages;
 	if(SteamNetworkingSockets() != NULL){
 		// Allocate the space for the messages
-		SteamNetworkingMessage_t *poll_messages;
+		SteamNetworkingMessage_t** poll_messages = new SteamNetworkingMessage_t*[max_messages];
 		// Get the messages
-		int available_messages = SteamNetworkingSockets()->ReceiveMessagesOnPollGroup((HSteamNetPollGroup)poll_group, &poll_messages, max_messages);
+		int available_messages = SteamNetworkingSockets()->ReceiveMessagesOnPollGroup((HSteamNetPollGroup)poll_group, poll_messages, max_messages);
 		// Loop through and create the messages as dictionaries then add to the messages array
 		for(int i = 0; i < available_messages; i++){
 			// Create the message dictionary to send back
 			Dictionary message;
 			// Get the message data
-			int message_size = poll_messages[i].m_cbSize;
+			int message_size = poll_messages[i]->m_cbSize;
 			PoolByteArray data;
 			data.resize(message_size);
-			uint8_t* source_data = (uint8_t*)poll_messages[i].m_pData;
+			uint8_t* source_data = (uint8_t*)poll_messages[i]->m_pData;
 			uint8_t* output_data = data.write().ptr();
 			for(int j = 0; j < message_size; j++){
 				output_data[j] = source_data[j];
 			}
 			message["payload"] = data;
 			message["size"] = message_size;
-			message["connection"] = poll_messages[i].m_conn;
+			message["connection"] = poll_messages[i]->m_conn;
 			char identity[STEAM_BUFFER_SIZE];
-			poll_messages[i].m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
+			poll_messages[i]->m_identityPeer.ToString(identity, STEAM_BUFFER_SIZE);
 			message["identity"] = identity;
-			message["user_data"] = (uint64_t)poll_messages[i].m_nConnUserData;
-			message["time_received"] = (uint64_t)poll_messages[i].m_usecTimeReceived;
-			message["message_number"] = (uint64_t)poll_messages[i].m_nMessageNumber;
-			message["channel"] = poll_messages[i].m_nChannel;
-			message["flags"] = poll_messages[i].m_nFlags;
-			message["user_data"] = (uint64_t)poll_messages[i].m_nUserData;
+			message["user_data"] = (uint64_t)poll_messages[i]->m_nConnUserData;
+			message["time_received"] = (uint64_t)poll_messages[i]->m_usecTimeReceived;
+			message["message_number"] = (uint64_t)poll_messages[i]->m_nMessageNumber;
+			message["channel"] = poll_messages[i]->m_nChannel;
+			message["flags"] = poll_messages[i]->m_nFlags;
+			message["user_data"] = (uint64_t)poll_messages[i]->m_nUserData;
 			messages.append(message);
 			// Release the message
-			poll_messages[i].Release();
+			poll_messages[i]->Release();
 		}
+		delete [] poll_messages;
 	}
 	return messages;
 }


### PR DESCRIPTION
Fixes receive message functions to allow for more than 1 message at a time

I was playing around with the SteamNetworkingMessage functions and was getting a crash when calling receivingMessagesOnChannel() with max_messages > 1
Not sure if it was the same error as described in https://github.com/Gramps/GodotSteam/pull/243#issue-1195317769

I have only tested receiveMessagesOnChannel() and not the NetworkingSockets functions receiveMessagesOnConnection() and receiveMessagesOnPollGroup(), but they behave the same way