### PR TITLE
Fix getQueryUGCChildren not working at all

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -7064,21 +7064,27 @@ Dictionary Steam::getQueryUGCAdditionalPreview(uint64_t query_handle, uint32 ind
 }
 
 //! Retrieve the ids of any child items of an individual workshop item after receiving a querying UGC call result. These items can either be a part of a collection or some other dependency (see AddDependency).
-Dictionary Steam::getQueryUGCChildren(uint64_t query_handle, uint32 index){
+Dictionary Steam::getQueryUGCChildren(uint64_t query_handle, uint32 index, uint32_t child_count){
 	Dictionary children;
 	if(SteamUGC() == NULL){
 		return children;
 	}
 	UGCQueryHandle_t handle = (uint64_t)query_handle;
-	PublishedFileId_t *child = new PublishedFileId_t[100];
-	bool success = SteamUGC()->GetQueryUGCChildren(handle, index, (PublishedFileId_t*)child, 100);
-	if(success){
+	PoolVector<uint64_t> vec;
+	vec.resize(child_count);
+	bool success = SteamUGC()->GetQueryUGCChildren(handle, index, (PublishedFileId_t*)vec.write().ptr(), child_count);
+	if(success) {
+		Array godot_arr;
+		godot_arr.resize(child_count);
+		for (uint32_t i = 0; i < child_count; i++) {
+			godot_arr[i] = vec[i];
+		}
+		
 		children["success"] = success;
 		children["handle"] = (uint64_t)handle;
 		children["index"] = index;
-		children["children"] = child;
+		children["children"] = godot_arr;
 	}
-	delete[] child;
 	return children;
 }
 
@@ -11852,7 +11858,7 @@ void Steam::_bind_methods(){
 	ClassDB::bind_method(D_METHOD("getItemUpdateProgress", "update_handle"), &Steam::getItemUpdateProgress);
 	ClassDB::bind_method("getNumSubscribedItems", &Steam::getNumSubscribedItems);
 	ClassDB::bind_method(D_METHOD("getQueryUGCAdditionalPreview", "query_handle", "index", "preview_index"), &Steam::getQueryUGCAdditionalPreview);
-	ClassDB::bind_method(D_METHOD("getQueryUGCChildren", "query_handle", "index"), &Steam::getQueryUGCChildren);
+	ClassDB::bind_method(D_METHOD("getQueryUGCChildren", "query_handle", "index", "child_count"), &Steam::getQueryUGCChildren);
 	ClassDB::bind_method(D_METHOD("getQueryUGCKeyValueTag", "query_handle", "index", "key_value_tag_index"), &Steam::getQueryUGCKeyValueTag);
 	ClassDB::bind_method(D_METHOD("getQueryUGCMetadata", "query_handle", "index"), &Steam::getQueryUGCMetadata);
 	ClassDB::bind_method(D_METHOD("getQueryUGCNumAdditionalPreviews", "query_handle", "index"), &Steam::getQueryUGCNumAdditionalPreviews);

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -1145,7 +1145,7 @@ class Steam: public Object {
 		Dictionary getItemUpdateProgress(uint64_t update_handle);
 		uint32 getNumSubscribedItems();
 		Dictionary getQueryUGCAdditionalPreview(uint64_t query_handle, uint32 index, uint32 preview_index);
-		Dictionary getQueryUGCChildren(uint64_t query_handle, uint32 index);
+		Dictionary getQueryUGCChildren(uint64_t query_handle, uint32 index, uint32_t child_count);
 		Dictionary getQueryUGCKeyValueTag(uint64_t query_handle, uint32 index, uint32 key_value_tag_index);
 		String getQueryUGCMetadata(uint64_t query_handle, uint32 index);
 		uint32 getQueryUGCNumAdditionalPreviews(uint64_t query_handle, uint32 index);


### PR DESCRIPTION
Previously, the children dictionary entry in getQueryUGCChildren would be a bool, this is because it used to try to simply set the dictionary entry to a raw pointer, which would cause it to be interpreted as a bool when converting it to a Variant.

The only caveat is that it requires knowing the child count ahead of time, but this is what steam expects anyways.