### PR TITLE
Adding build workflows for win64, linux64

### DIFF
--- a/.github/workflows/build-linux-artifact.yml
+++ b/.github/workflows/build-linux-artifact.yml
@@ -1,0 +1,83 @@
+on:
+  workflow_call:
+    inputs:
+      steamworks_sdk_tag:
+        required: true
+        type: string
+      godot_tag:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+      build_params:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      export_name:
+        required: true
+        type: string
+    secrets:
+      steamworks_sdk_repo:
+        required: true
+      steamworks_sdk_repo_token:
+        required: true
+
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    
+    steps:
+      # Checkout Godot
+      - name: Checkout Godot
+        uses: actions/checkout@v3
+        with:
+          repository: "godotengine/godot"
+          path: "godot"
+          ref: ${{ inputs.godot_tag }}
+      # Checkout current source of GodotSteam
+      - name: Checkout GodotSteam
+        uses: actions/checkout@v3
+        with:
+          path: "godotsteam"
+      - name: Copy GodotSteam Module
+        run: |
+          cp -r godotsteam/godotsteam godot/modules
+      # Checkout Steamworks SDK
+      - name: Checkout Steamworks SDK
+        uses: actions/checkout@v3
+        with:
+          path: "steamworks"
+          repository: ${{ secrets.steamworks_sdk_repo }}
+          token: ${{ secrets.steamworks_sdk_repo_token }}
+          ref: ${{ inputs.steamworks_sdk_tag }}
+      - name: Copy Steamworks
+        run: |
+          cp -r steamworks/sdk/public godot/modules/godotsteam/sdk
+          cp -r steamworks/sdk/redistributable_bin godot/modules/godotsteam/sdk
+          ls -la godot/modules/godotsteam/sdk
+      - name: Install Build Requirements
+        run: |
+          sudo apt-get install -y build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \
+          libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+      - name: Build Linux Editor
+        working-directory: "godot"
+        run: |
+          scons ${{ inputs.build_params }}
+          mv bin/${{ inputs.binary_name }} bin/${{ inputs.export_name }}
+          ls -la bin
+      - name: Upload Linux Build
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: godot/bin/${{ inputs.export_name }}
+          retention-days: 1
+      - name: Upload Linux Steam File
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-libsteam-api-so
+          path: godot/modules/godotsteam/sdk/redistributable_bin/linux64/libsteam_api.so
+          retention-days: 1

--- a/.github/workflows/build-linux-artifact.yml
+++ b/.github/workflows/build-linux-artifact.yml
@@ -28,7 +28,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     
     steps:
       # Checkout Godot

--- a/.github/workflows/build-osx-artifact.yml
+++ b/.github/workflows/build-osx-artifact.yml
@@ -1,0 +1,84 @@
+on:
+  workflow_call:
+    inputs:
+      steamworks_sdk_tag:
+        required: true
+        type: string
+      godot_tag:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+      build_params:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      export_name:
+        required: true
+        type: string
+      template_path:
+        required: true
+        type: string
+    secrets:
+      steamworks_sdk_repo:
+        required: true
+      steamworks_sdk_repo_token:
+        required: true
+
+
+jobs:
+  build-linux:
+    runs-on: osx-latest
+    
+    steps:
+      # Checkout Godot
+      - name: Checkout Godot
+        uses: actions/checkout@v3
+        with:
+          repository: "godotengine/godot"
+          path: "godot"
+          ref: ${{ inputs.godot_tag }}
+      # Checkout current source of GodotSteam
+      - name: Checkout GodotSteam
+        uses: actions/checkout@v3
+        with:
+          path: "godotsteam"
+      - name: Copy GodotSteam Module
+        run: |
+          cp -r godotsteam/godotsteam godot/modules
+      # Checkout Steamworks SDK
+      - name: Checkout Steamworks SDK
+        uses: actions/checkout@v3
+        with:
+          path: "steamworks"
+          repository: ${{ secrets.steamworks_sdk_repo }}
+          token: ${{ secrets.steamworks_sdk_repo_token }}
+          ref: ${{ inputs.steamworks_sdk_tag }}
+      - name: Copy Steamworks
+        run: |
+          cp -r steamworks/sdk/public godot/modules/godotsteam/sdk
+          cp -r steamworks/sdk/redistributable_bin godot/modules/godotsteam/sdk
+          ls -la godot/modules/godotsteam/sdk
+      - name: Install Build Tools
+        run: |
+          brew install scons yasm
+      - name: Build OSX x86_64
+        working-directory: "godot"
+        run: |
+          scons ${{ inputs.build_params }}
+          mv bin/${{ inputs.binary_name }} bin/${{ inputs.export_name }}
+      - name: Upload OSX Build
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: godot/bin/${{ inputs.export_name }}
+          retention-days: 1
+      - name: Upload OSX Steam dylib
+        uses: actions/upload-artifact@v3
+        with:
+          name: osx-libsteam-api-so
+          path: godot/modules/godotsteam/sdk/redistributable_bin/osx/libsteam_api.dylib
+          retention-days: 1

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -1,0 +1,275 @@
+name: Build Releases
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  STEAMWORKS_SDK_TAG: "153a"
+  GODOT_TAG: "3.4.4-stable"
+
+jobs:
+  env-setup:
+    name: "Setup env variables"
+    runs-on: ubuntu-latest
+    outputs:
+      steamworks_sdk_tag: ${{ steps.set-steamworks-sdk-tag.outputs.steamworks_sdk_tag }}
+      godot_tag: ${{ steps.set-godot-tag.outputs.godot_tag }}
+    steps:
+      - id: set-steamworks-sdk-tag
+        run: |    
+          echo "::set-output name=steamworks_sdk_tag::${{ env.STEAMWORKS_SDK_TAG }}"
+      - id: set-godot-tag
+        run: |    
+          echo "::set-output name=godot_tag::${{ env.GODOT_TAG }}"
+
+################# Linux 64 Builds #################
+
+  build-linux-editor:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-linux-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: "godot.x11.opt.tools.64"
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-editor-x11.64"
+      build_params: "-j4 platform=x11 production=yes tools=yes target=release_debug bits=64"
+      artifact_name: "linux-editor"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  build-linux-release-template:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-linux-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: "godot.x11.opt.64"
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-template-x11.64"
+      build_params: "-j4 platform=x11 production=yes tools=no target=release bits=64"
+      artifact_name: "linux-release-template"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  build-linux-debug-template:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-linux-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: "godot.x11.opt.debug.64"
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-debug-template-x11.64"
+      build_params: "-j4 platform=x11 production=yes tools=no target=release_debug bits=64"
+      artifact_name: "linux-debug-template"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  build-linux-headless:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-linux-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: godot_server.x11.opt.tools.64
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-editor-headless.64"
+      build_params: "-j4 platform=server production=yes tools=yes target=release_debug bits=64"
+      artifact_name: "linux-headless"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  create-linux-bundle:
+    needs: [build-linux-editor, build-linux-release-template, build-linux-debug-template]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Linux Editor
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-editor
+          path: files
+      - name: Download Linux Release Template
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-release-template
+          path: files
+      - name: Download Linux Debug Template
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-debug-template
+          path: files
+      - name: Download Linux Steam API
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-libsteam-api-so
+          path: files
+      - name: Create Linux Bundle
+        run: |
+          echo "480" >> files/steam_appid.txt
+          ls -la files
+          zip -j linux-${{ env.GODOT_TAG }}-x11-64bit.zip files/*
+      - name: Upload bundle to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: linux-${{ env.GODOT_TAG }}-x11-64bit.zip
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+
+  create-headless-bundle:
+    needs: [build-linux-headless]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Linux Headless
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-headless
+          path: files
+      - name: Download Linux Steam API
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-libsteam-api-so
+          path: files
+      - name: Create Linux Headless Bundle
+        run: |
+          echo "480" >> files/steam_appid.txt
+          ls -la files
+          zip -j linux-${{ env.GODOT_TAG }}-headless-64bit.zip files/*
+      - name: Upload bundle to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: linux-${{ env.GODOT_TAG }}-headless-64bit.zip
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+
+################# Win64 Builds #################
+  
+  build-win64-editor:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-windows-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: godot.windows.opt.tools.64.exe
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-editor-win64.exe"
+      build_params: "-j4 platform=windows production=yes tools=yes target=release_debug debug_symbols=no"
+      artifact_name: "win64-editor"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  build-win64-release-template:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-windows-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: godot.windows.opt.64.exe
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-template-win64.exe"
+      build_params: "-j4 platform=windows production=yes tools=no target=release debug_symbols=no"
+      artifact_name: "win64-release-template"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  build-win64-debug-template:
+    needs: [env-setup]
+    uses: ./.github/workflows/build-windows-artifact.yml
+    with:
+      steamworks_sdk_tag: ${{needs.env-setup.outputs.steamworks_sdk_tag}}
+      godot_tag: ${{needs.env-setup.outputs.godot_tag}}
+      binary_name: godot.windows.opt.debug.64.exe
+      export_name: "GodotSteam-${{needs.env-setup.outputs.godot_tag}}-debug-template-win64.exe"
+      build_params: "-j4 platform=windows production=yes tools=no target=release_debug debug_symbols=no"
+      artifact_name: "win64-debug-template"
+    secrets:
+      steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
+      steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
+
+  create-win64-bundle:
+    needs: [build-win64-editor, build-win64-release-template, build-win64-debug-template]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Windows Editor
+        uses: actions/download-artifact@v3
+        with:
+          name: win64-editor
+          path: files
+      - name: Download Windows Release Template
+        uses: actions/download-artifact@v3
+        with:
+          name: win64-release-template
+          path: files
+      - name: Download Windows Debug Template
+        uses: actions/download-artifact@v3
+        with:
+          name: win64-debug-template
+          path: files
+      - name: Download Windows Steam API
+        uses: actions/download-artifact@v3
+        with:
+          name: win_steam_api
+          path: files
+      - name: Create Windows Bundle
+        run: |
+          echo "480" >> files/steam_appid.txt
+          ls -la files
+          zip -j windows-${{ env.GODOT_TAG }}-64bit.zip files/*
+      - name: Upload bundle to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: windows-${{ env.GODOT_TAG }}-64bit.zip
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+
+################# OSX Universal Builds #################
+
+
+################# Create Template Bundles #################
+  create-templates-bundle:
+    needs: [build-linux-release-template, build-linux-debug-template, build-win64-release-template, build-win64-debug-template]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Windows Release Template
+        uses: actions/download-artifact@v3
+        with:
+          name: win64-release-template
+          path: files
+      - name: Download Windows Debug Template
+        uses: actions/download-artifact@v3
+        with:
+          name: win64-debug-template
+          path: files
+      - name: Download Windows Steam API
+        uses: actions/download-artifact@v3
+        with:
+          name: win_steam_api
+          path: files
+      - name: Download Linux Release Template
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-release-template
+          path: files
+      - name: Download Linux Debug Template
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-debug-template
+          path: files
+      - name: Download Linux Steam API
+        uses: actions/download-artifact@v3
+        with:
+          name: linux-libsteam-api-so
+          path: files
+      - name: Create Template Bundle
+        run: |
+          echo "480" >> files/steam_appid.txt
+          ls -la files
+          zip -j godotsteam-${{ env.GODOT_TAG }}-templates.zip files/*
+      - name: Upload bundle to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: godotsteam-${{ env.GODOT_TAG }}-templates.zip
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/build-windows-artifact.yml
+++ b/.github/workflows/build-windows-artifact.yml
@@ -1,0 +1,89 @@
+on:
+  workflow_call:
+    inputs:
+      steamworks_sdk_tag:
+        required: true
+        type: string
+      godot_tag:
+        required: true
+        type: string
+      binary_name:
+        required: true
+        type: string
+      build_params:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      export_name:
+        required: true
+        type: string
+    secrets:
+      steamworks_sdk_repo:
+        required: true
+      steamworks_sdk_repo_token:
+        required: true
+
+
+jobs:
+  build-linux:
+    runs-on: windows-latest
+    
+    steps:
+      # Checkout Godot
+      - name: Checkout Godot
+        uses: actions/checkout@v3
+        with:
+          repository: "godotengine/godot"
+          path: "godot"
+          ref: ${{ inputs.godot_tag }}
+      # Checkout current source of GodotSteam
+      - name: Checkout GodotSteam
+        uses: actions/checkout@v3
+        with:
+          path: "godotsteam"
+      - name: Copy GodotSteam Module
+        run: |
+          dir
+          robocopy godotsteam/godotsteam godot/modules/godotsteam /e
+          cd godot/modules/godotsteam && dir
+          EXIT 0
+      # Checkout Steamworks SDK
+      - name: Checkout Steamworks SDK
+        uses: actions/checkout@v3
+        with:
+          path: "steamworks"
+          repository: ${{ secrets.steamworks_sdk_repo }}
+          token: ${{ secrets.steamworks_sdk_repo_token }}
+          ref: ${{ inputs.steamworks_sdk_tag }}
+      - name: Copy Steamworks
+        run: |
+          robocopy steamworks/sdk/public godot/modules/godotsteam/sdk/public /e
+          robocopy steamworks/sdk/redistributable_bin godot/modules/godotsteam/sdk/redistributable_bin /e
+          cd godot/modules/godotsteam/sdk && dir
+          EXIT 0
+      - name: Install Build Requirements
+        run: |
+          python --version
+          python -m pip install scons
+          scons --version
+          
+      - name: Build Windows
+        working-directory: "godot"
+        run: |
+          scons ${{ inputs.build_params }}
+          cd bin && ren ${{ inputs.binary_name }} ${{ inputs.export_name }}
+      - name: Upload Windows Build
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: godot/bin/${{ inputs.export_name }}
+          retention-days: 1
+      - name: Upload Windows Steam File
+        uses: actions/upload-artifact@v3
+        with:
+          name: win_steam_api
+          path: |
+            godot/modules/godotsteam/sdk/redistributable_bin/win64/steam_api64.dll
+          retention-days: 1


### PR DESCRIPTION
This PR adds automated builds for Win64 (editor, release template and debug template), Linux64 (editor, release template, debug template) and Linux64 Headless (editor).

It requires the Steamworks SDK in order to compile GodotSteam properly. You will need to add that to a private repo and tag the versions appropriately. I have tested it locally with the tag  "153a" on the private JDare/Steamworks-SDK repo. You will also need to add a Personal Access Token which has access to that repo in order to pull its contents at build time. These should be added as the following secrets to this repo:

STEAMWORKS_SDK_REPO: Gramps/Steamworks-SDK (or whatever you call it)
STEAMWORKS_SDK_REPO_TOKEN: <your personal access token>

To bump dependencies in the future you can simple edit the env parameters at the top of the `build-releases.yml` file. I have them set to `STEAMWORKS_SDK_TAG: "153a"` and `GODOT_TAG: "3.4.4-stable"` currently.

Theres also some stubbed out code for creating OSX Builds, however I don't have time to jump into that right now. Its harmless as its not called, but its a great starting point if anyone else wants to add that. I can also remove it from this PR if you don't want it there.