### PR TITLE
Update texture construction code in documentation

### DIFF
--- a/tutorials-achievement-icons.html
+++ b/tutorials-achievement-icons.html
@@ -43,26 +43,18 @@ var BUFFER: Dictionary = Steam.getImageRGBA(HANDLE)
 	<header class="major">
 		<h3>Creating The Image</h3>
 	</header>
-	<p>This buffer contains the actual image data for our icon but is rather tricky to use.  However, before that we will need to create a new image and texture to attach to a sprite later on:
+	<p>This buffer contains the actual image data for our icon. However, as this buffer is simply binary data, we need to load it into an Image so that Godot can use it as a Texture:
 <pre><code>
 var SIZE: int = 32
 var ICON: Image = Image.new()
 var ICON_TEXTURE: ImageTexture = ImageTexture.new()
-ICON.create(SIZE, SIZE, false, Image.FORMAT_RGBAF)
+
 </code></pre>
 	<p>The size variable can be whatever you want; for our example we will use 32 (32 pixels by 32 pixels).</p>
-	<p>Now let's go back and parse that buffer data:</p>
+	<p>Now that we've made our Image and Texture objects, we can load the buffer data into the Image. Note the format we use (RGBA8); this is the format the data in the buffer takes when we receive it from Steam,
+		and so in order for Godot to know how to make sense of it, we need to ensure it is correct:</p>
 <pre><code>
-ICON.lock()
-for y in range(0, SIZE):
-	for x in range(0, SIZE):
-		var pixel: int = 4 * (x + y * SIZE)
-		var r: float = float(BUFFER['buffer'][pixel]) / 255
-		var g: float = float(BUFFER['buffer'][pixel+1]) / 255
-		var b: float = float(BUFFER['buffer'][pixel+2]) / 255
-		var a: float = float(BUFFER['buffer'][pixel+3]) / 255
-		ICON.set_pixel(x, y, Color(r, g, b, a))
-ICON.unlock()
+	ICON.create_from_data(SIZE, SIZE, false, Image.FORMAT_RGBA8, buffer)
 </code></pre>
 	<p>Now that all the pixels are set in the right places, we can create the texture:</p>
 <pre><code>	
@@ -89,19 +81,7 @@ var BUFFER: Dictionary = Steam.getImageRGBA(HANDLE)
 #Create the image and texture for loading
 var ICON: Image = Image.new()
 var ICON_TEXTURE: ImageTexture = ImageTexture.new()
-ICON.create(SIZE, SIZE, false, Image.FORMAT_RGBAF)
-
-# Lock and draw the image
-ICON.lock()
-for y in range(0, SIZE):
-	for x in range(0, SIZE):
-		var pixel: int = 4 * (x + y * SIZE)
-		var r: float = float(BUFFER['buffer'][pixel]) / 255
-		var g: float = float(BUFFER['buffer'][pixel+1]) / 255
-		var b: float = float(BUFFER['buffer'][pixel+2]) / 255
-		var a: float = float(BUFFER['buffer'][pixel+3]) / 255
-		ICON.set_pixel(x, y, Color(r, g, b, a))
-ICON.unlock()
+ICON.create_from_data(SIZE, SIZE, false, Image.FORMAT_RGBA8, buffer)
 
 # Apply it to the texture
 ICON_TEXTURE.create_from_image(ICON)

--- a/tutorials-avatars.html
+++ b/tutorials-avatars.html
@@ -48,31 +48,16 @@ Steam.connect("avatar_loaded", self, "loaded_avatar")
 </code></pre>
 	<p>This will return the user's Steam ID, the avatar's size, and the data buffer for rendering the image.  If you have read the <a href="tutorials-achievement-icons.html">Achievement Icons tutorial</a>, this should all look pretty familiar.  Our <strong>loaded_avatar</strong> function will look something like this:</p>
 <pre><code>
-func loaded_avatar(id: int, size: int, buffer: PoolByteArray) -> void:
+func _loaded_Avatar(id: int, size: int, buffer: PoolByteArray) -> void:
 	print("Avatar for user: "+str(id))
 	print("Size: "+str(size))
-
-	# Create a new image and texture to fill out
-	var AVATAR: Image = Image.new()
+	# Create the image and texture for loading
+	AVATAR = Image.new()
 	var AVATAR_TEXTURE: ImageTexture = ImageTexture.new()
-	AVATAR.create(size, size, false, Image.FORMAT_RGBAF)
-
-	# Lock the image and fill the pixels from the data buffer
-	AVATAR.lock()
-	for y in range(0, size):
-		for x in range(0, size):
-			var pixel: int = 4 * (x + y * size)
-			var r: float = float(buffer[pixel]) / 255
-			var g: float = float(buffer[pixel+1]) / 255
-			var b: float = float(buffer[pixel+2]) / 255
-			var a: float = float(buffer[pixel+3]) / 255
-			AVATAR.set_pixel(x, y, Color(r, g, b, a))
-	AVATAR.unlock()
-
-	# Now apply the texture
+	AVATAR.create_from_data(size, size, false, Image.FORMAT_RGBA8, buffer)
+	# Apply it to the texture
 	AVATAR_TEXTURE.create_from_image(AVATAR)
-
-	# For our purposes, set a sprite with the avatar texture
+	# Set it
 	$Sprite.set_texture(AVATAR_TEXTURE)
 </code></pre>
 <p>Naturally that texture could be applied elsewhere, depending on where you place this function.</p>


### PR DESCRIPTION
As of Godot 3.X.Y, Images are able to be built directly in a much more performant manner by directly calling `create_from_data(height, width, use_mipmaps, format, buffer)`. This PR changes the tutorial code to reflect this, enabling users of the tutorial to have faster construction of player Avatars and Achievement Icons, which were a point of performance issues when large lobbies were connected to (> 10 players). 