### PR TITLE
update locations data structure

### DIFF
--- a/godotsteam/doc_classes/Steam.xml
+++ b/godotsteam/doc_classes/Steam.xml
@@ -518,7 +518,7 @@
 		</method>
 		<method name="convertPingLocationToString">
 			<return type="String" />
-			<argument index="0" name="location" type="int" />
+			<argument index="0" name="location" type="PoolByteArray" />
 			<description>
 			</description>
 		</method>
@@ -846,14 +846,14 @@
 		</method>
 		<method name="estimatePingTimeBetweenTwoLocations">
 			<return type="int" />
-			<argument index="0" name="location1" type="int" />
-			<argument index="1" name="location2" type="int" />
+			<argument index="0" name="location1" type="PoolByteArray" />
+			<argument index="1" name="location2" type="PoolByteArray" />
 			<description>
 			</description>
 		</method>
 		<method name="estimatePingTimeFromLocalHost">
 			<return type="int" />
-			<argument index="0" name="location" type="int" />
+			<argument index="0" name="location" type="PoolByteArray" />
 			<description>
 			</description>
 		</method>

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -1040,9 +1040,9 @@ class Steam: public Object {
 		
 		// Networking Utils /////////////////////
 		bool checkPingDataUpToDate(float max_age_in_seconds);
-		String convertPingLocationToString(uint8 location);
-		int estimatePingTimeBetweenTwoLocations(uint8 location1, uint8 location2);
-		int estimatePingTimeFromLocalHost(uint8 location);
+		String convertPingLocationToString(PoolByteArray location);
+		int estimatePingTimeBetweenTwoLocations(PoolByteArray location1, PoolByteArray location2);
+		int estimatePingTimeFromLocalHost(PoolByteArray location);
 		Dictionary getConfigValue(int config_value, int scope_type, uint32_t connection_handle);
 		Dictionary getConfigValueInfo(int config_value);
 		int getDirectPingToPOP(uint32 pop_id);


### PR DESCRIPTION
SteamAPI::GetLocalPingLocation return the age of the data and edit (by reference)
the result SteamNetworkPingLocation_t which contains the location.

From Steam point of view, a location is an array of 512 bytes-length.
This is an opaque item that can be changed to String to be sent over network and
deserialized by after.

The commit changes all methods that uses location to take the location structure:

getLocalPingLocation
estimatePingTimeBetweenTwoLocations
estimatePingTimeFromLocalHost
convertPingLocationToString
parsePingLocationString