### PR TITLE
Update leaderboard callback signatures in docs

### DIFF
--- a/godotsteam/doc_classes/Steam.xml
+++ b/godotsteam/doc_classes/Steam.xml
@@ -5430,16 +5430,18 @@
 		</signal>
 		<signal name="leaderboard_score_uploaded">
 			<argument index="0" name="success" type="bool" />
-			<argument index="1" name="score" type="int" />
-			<argument index="2" name="score_changed" type="bool" />
-			<argument index="3" name="global_rank_new" type="int" />
-			<argument index="4" name="global_rank_previous" type="int" />
+			<argument index="1" name="leaderboard_handle" type="int" />
+			<argument index="2" name="score" type="int" />
+			<argument index="3" name="score_changed" type="bool" />
+			<argument index="4" name="global_rank_new" type="int" />
+			<argument index="5" name="global_rank_previous" type="int" />
 			<description>
 			</description>
 		</signal>
 		<signal name="leaderboard_scores_downloaded">
 			<argument index="0" name="message" type="String" />
-			<argument index="1" name="leaderboard_entries" type="Array" />
+			<argument index="1" name="leaderboard_handle" type="int" />
+			<argument index="2" name="leaderboard_entries" type="Array" />
 			<description>
 			</description>
 		</signal>


### PR DESCRIPTION
As discovered in release `g351-s155-gs3175`, when migrating from `g344-s154-gs3161`, the signature for the following leaderboard callback functions have changed, inserting a new (welcome) leaderboard handle parameter. This PR updates the docs to reflect the new signature.

* `leaderboard_score_uploaded`
* `leaderboard_scores_downloaded`

Edit: Signature updates occurred here: https://github.com/Gramps/GodotSteam/commit/8f29493f3bf1326171cb97eafe155dbc36e2f621