### PR TITLE
Fix `io_failure` param name in `steamworks_error` signal

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -11610,7 +11610,7 @@ void Steam::_bind_methods(){
 	/////////////////////////////////////////////
 	//
 	// STEAMWORKS SIGNALS ///////////////////////
-	ADD_SIGNAL(MethodInfo("steamworks_error", PropertyInfo(Variant::STRING, "failed_signal"), PropertyInfo(Variant::STRING, "io failure")));
+	ADD_SIGNAL(MethodInfo("steamworks_error", PropertyInfo(Variant::STRING, "failed_signal"), PropertyInfo(Variant::STRING, "io_failure")));
 
 	// APPS SIGNALS /////////////////////////////
 	ADD_SIGNAL(MethodInfo("file_details_result", PropertyInfo(Variant::INT, "result"), PropertyInfo(Variant::INT, "file_size"), PropertyInfo(Variant::INT, "file_hash"), PropertyInfo(Variant::INT, "flags")));


### PR DESCRIPTION
Parameters can't have spaces in their names.

This was causing Godot 4.0 .NET compilation to fail because it generated an event delegate with the parameter name "io failure" which is not valid because it contains a space.

In 3.x signals are not generated in C# so it doesn't really matter but spaces are still not valid in identifiers as far as I'm concerned so it's probably a good idea to avoid them.