### PR TITLE
Add build output and Steam SDK to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
+# C/C++ generated
+*.a
+*.ax
+*.d
+*.dll
+*.lib
+*.lo
+*.o
+*.os
+*.ox
+*.Plo
+*.so
+
+# Python generated
+__pycache__/
+*.pyc
+
+# Steam SDK
+sdk/*
+!sdk/put SDK here
+
+# Doxygen
 doxygen/


### PR DESCRIPTION
This should help avoid accidentally committing the result of a build or the Steam SDK to git.

If you clone this repo inside Godot [their gitignore](https://github.com/godotengine/godot/blob/0d28820c816fa66b66a98cc6c9df25ff74cbb19f/.gitignore) already applies which contains ignores for the build output already, I clone this repo outside the Godot directory so I find it useful to also add the build output to the gitignore but let me know if that's not wanted.