### PR TITLE
Compile universal library for macOS. 

### DIFF
--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -39,6 +39,7 @@ jobs:
           scons platform=osx macos_arch=${{ matrix.architecture }} generate_bindings=yes target=release
           cd ..
           mkdir bin
+          ls
       - name: Compile GodotSteam
         run: |
           scons platform=osx macos_arch=${{ matrix.architecture }} production=yes target=release

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -50,6 +50,8 @@ jobs:
         run: |
           ls -al
           ls -al bin/osx
+          cd bin/osx 
+          mv libgodotsteam.dylib libgodotsteam-${{ matrix.architecture }}.dylib
       - name: Upload macOS dylib
         uses: actions/upload-artifact@v3
         with:
@@ -76,3 +78,8 @@ jobs:
         run: |
           cd dylibs
           lipo libgodotsteam-x86_64.dylib libgodotsteam-arm64.dylib -output libgodotsteam.dylib -create
+      - uses: actions/upload-artifact@v3
+        name: Upload final dylib
+        with:
+          name: macos-plugin-universal
+          path: dylibs/libgodotsteam.dylib

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -52,6 +52,7 @@ jobs:
           ls -al bin/osx
           cd bin/osx 
           mv libgodotsteam.dylib libgodotsteam-${{ matrix.architecture }}.dylib
+          cd ..
       - name: Upload macOS dylib
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -1,0 +1,74 @@
+on: push
+
+env:
+  STEAMWORKS_SDK_TAG: "sdk-1.55"
+
+jobs:
+  build_macos:
+    strategy:
+      matrix:
+        architecture: ['x86_64', 'arm64']
+    runs-on: macos-latest
+    steps:
+      # Need to download godot-cpp, compile it, and the steamworks sdk
+      # Checkout current source of GodotSteam
+      - name: Checkout GodotSteam
+        uses: actions/checkout@v3
+      - name: Install Build Tools
+        run: |
+          brew install scons yasm
+       # Checkout Steamworks SDK
+      - name: Checkout Steamworks SDK
+        uses: actions/checkout@v3
+        with:
+          path: "steamworks"
+          repository: ${{ secrets.steamworks_sdk_repo }}
+          token: ${{ secrets.steamworks_sdk_repo_token }}
+          ref: ${{ STEAMWORKS_SDK_TAG }}
+      - name: Copy Steamworks
+        run: |
+          cp -r steamworks/public godotsteam/sdk
+          cp -r steamworks/redistributable_bin godotsteam/sdk
+          ls -la 
+          ls -la godotsteam/sdk
+      - name: Checkout godot-cpp
+        run: git clone --recursive -b 3.5 https://github.com/godotengine/godot-cpp
+      - name: Compile godot-cpp
+        run: |
+          cd godot-cpp
+          scons platform=osx macos_arch=${{ matrix.architecture }} generate_bindings=yes target=release
+          cd ..
+          mkdir bin
+      - name: Compile GodotSteam
+        run: |
+          scons platform=osx macos_arch=${{ matrix.architecture }} production=yes target=release
+      - name: Print compiled
+        run: |
+          ls -al
+          ls -al bin/osx
+      - name: Upload macOS dylib
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos-plugin-${{ matrix.architecture }}
+          path: bin/osx/libgodotsteam-${{ matrix.architecture }}.dylib
+          if-no-files-found: error
+          retention-days: 1
+  
+  bundle_universal:
+    needs: [build_macos]
+    runs-on: macos-latest
+    steps:
+      - name: Download x86_64
+        uses: actions/download-artifact@v3
+        with:
+          name: libgodotsteam-x86_64.dylib
+          path: dylibs
+      - name: Download arm64
+        uses: actions/download-artifact@v3
+        with:
+          name: libgodotsteam-arm64.dylib
+          path: dylibs
+      - name: Bundle together
+        run: |
+          cd dylibs
+          lipo libgodotsteam-x86_64.dylib libgodotsteam-arm64.dylib -output libgodotsteam.dylib -create

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -37,6 +37,8 @@ jobs:
         run: |
           cd godot-cpp
           scons platform=osx macos_arch=${{ matrix.architecture }} generate_bindings=yes target=release
+          ls -al
+          echo "Done building godot-cpp, and showing output"
           cd ..
           mkdir bin
           ls

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -38,6 +38,7 @@ jobs:
           cd godot-cpp
           scons platform=osx macos_arch=${{ matrix.architecture }} generate_bindings=yes target=release
           ls -al
+          ls -al bin/osx
           echo "Done building godot-cpp, and showing output"
           cd ..
           mkdir bin

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -38,7 +38,7 @@ jobs:
           cd godot-cpp
           scons platform=osx macos_arch=${{ matrix.architecture }} generate_bindings=yes target=release
           ls -al
-          ls -al bin/osx
+          ls -al bin/
           echo "Done building godot-cpp, and showing output"
           cd ..
           mkdir bin

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -24,7 +24,7 @@ jobs:
           path: "steamworks"
           repository: ${{ secrets.steamworks_sdk_repo }}
           token: ${{ secrets.steamworks_sdk_repo_token }}
-          ref: ${{ STEAMWORKS_SDK_TAG }}
+          ref: "sdk-1.55"
       - name: Copy Steamworks
         run: |
           cp -r steamworks/public godotsteam/sdk

--- a/.github/workflows/build-mac-plugin.yaml
+++ b/.github/workflows/build-mac-plugin.yaml
@@ -68,12 +68,12 @@ jobs:
       - name: Download x86_64
         uses: actions/download-artifact@v3
         with:
-          name: libgodotsteam-x86_64.dylib
+          name: macos-plugin-x86_64
           path: dylibs
       - name: Download arm64
         uses: actions/download-artifact@v3
         with:
-          name: libgodotsteam-arm64.dylib
+          name: macos-plugin-arm64
           path: dylibs
       - name: Bundle together
         run: |

--- a/SConstruct
+++ b/SConstruct
@@ -111,8 +111,11 @@ if env['target'] in ('debug', 'd'):
 else:
     cpp_library += '.release'
 
-if env['platform'] == 'osx' and env['macos_arch'] == 'x86_64':
-    cpp_library += '.' + 'x86_64'
+if env['platform'] == 'osx':
+    if env['macos_arch'] == 'x86_64':
+        cpp_library += '.' + 'x86_64'
+    else:
+        cpp_library += '.' + 'arm64'
 else:
     cpp_library += '.' + str(bits)
 

--- a/SConstruct
+++ b/SConstruct
@@ -111,7 +111,10 @@ if env['target'] in ('debug', 'd'):
 else:
     cpp_library += '.release'
 
-cpp_library += '.' + str(bits)
+if env['platform'] == 'osx' and env['macos_arch'] == 'x86_64':
+    cpp_library += '.' + 'x86_64'
+else:
+    cpp_library += '.' + str(bits)
 
 # make sure our binding library is properly includes
 env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/', 'godotsteam/sdk/public'])

--- a/SConstruct
+++ b/SConstruct
@@ -13,6 +13,7 @@ opts.Add(EnumVariable('p', "Compilation target, alias for 'platform'", '', ['', 
 opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
 opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
 opts.Add(PathVariable('target_name', 'The library name.', 'godotsteam', PathVariable.PathAccept))
+opts.Add(EnumVariable('macos_arch', "Compilation architecture", 'arm64', ['x86_64', 'arm64']))
 
 # Local dependency paths, adapt them to your setup
 godot_headers_path = "godot-cpp/godot-headers/"
@@ -51,12 +52,18 @@ if env['platform'] == '':
 if env['platform'] == "osx":
     env['target_path'] += 'osx/'
     cpp_library += '.osx'
+    if env["macos_arch"] == "x86_64":
+        env.Append(CCFLAGS = ['-g','-O2', '-arch', 'x86_64', '-std=c++17'])
+        env.Append(LINKFLAGS = ['-arch', 'x86_64'])
+    else: # Default to ARM since M1/M2 is the future for mac
+        env.Append(CCFLAGS = ['-g','-O2', '-arch', 'arm64', '-std=c++17'])
+        env.Append(LINKFLAGS = ['-arch', 'arm64'])
+
     if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS=['-g', '-O2', '-arch', 'x86_64', '-arch', 'arm64', '-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-arch', 'arm64'])
+        env.Append(CCFLAGS = ['-g','-O2', '-std=c++17'])
     else:
-        env.Append(CCFLAGS=['-g', '-O3', '-arch', 'x86_64', '-arch', 'arm64', '-std=c++17'])
-        env.Append(LINKFLAGS=['-arch', 'x86_64', '-arch', 'arm64'])
+        env.Append(CCFLAGS=['-g', '-O3', '-std=c++17'])
+    
     # Set the correct Steam library
     steam_lib_path += "/osx"
     steamworks_library = 'libsteam_api.dylib'


### PR DESCRIPTION
This PR adds in CI which will compile a universal library for macOS for the plugin version of GodotSteam. Following this PR, more CI to build the windows and linux plugins will be added, but for now as this is the 'least updated' version of the plugin, it was figured this was most in need. 