### PR TITLE
Make SCons copy the steam library to bin, add dependency to gdextension

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Feel free to chat with us about GodotSteam on the [CoaguCo Discord server](https
 
 Current Build
 ---
-We currently do not have an in-depth how-to for this branch but it is coming.  However, it is functional thanks to the great work of @vaaris!  Since this is still an early work-in-progress, please except bugs and do not use this for production.  All pull requests are welcome!
+We currently do not have an in-depth how-to for this branch but it is coming.  However, it is functional thanks to the great work of @vaartis!  Since this is still an early work-in-progress, please except bugs and do not use this for production.  All pull requests are welcome!
 
 Donate
 ---

--- a/SConstruct
+++ b/SConstruct
@@ -61,6 +61,7 @@ env.Append(CPPPATH=['godotsteam/'])
 sources = Glob('godotsteam/*.cpp')
 
 library = env.SharedLibrary(target=env['target_path'] + env['target_name'] + env["suffix"] + env["SHLIBSUFFIX"], source=sources)
+env.Depends(library, Command("bin/" + steamworks_library, steam_lib_path + "/" + steamworks_library, Copy("$TARGET", "$SOURCE")))
 
 Default(library)
 

--- a/SConstruct
+++ b/SConstruct
@@ -12,10 +12,6 @@ opts.Add(PathVariable('target_name', 'The library name.', 'godotsteam', PathVari
 
 # Local dependency paths, adapt them to your setup
 steam_lib_path = "godotsteam/sdk/redistributable_bin"
-steam_lib = "steam_api"
-
-# only support 64 at this time..
-bits = 64
 
 # Updates the environment with the option variables.
 opts.Update(env)
@@ -42,19 +38,18 @@ elif env['platform'] in ('linuxbsd', 'linux'):
 elif env['platform'] == "windows":
     # This makes sure to keep the session environment variables on windows,
     # that way you can run scons in a vs 2017 prompt and it will find all the required tools
-    env.Append(ENV=os.environ)
+    # env.Append(ENV=os.environ)
 
     # Set correct Steam library
     steam_lib_path += "/win64"
-    steamworks_library = 'steam_api64.lib'
-    steam_lib = "steam_api64.lib"
-    if env["CC"] == "cl":
-        env.Append(LINKFLAGS=[ steam_lib ])
+    steamworks_library = 'steam_api64.dll'
 
 # make sure our binding library is properly includes
 env.Append(LIBPATH=[steam_lib_path])
 env.Append(CPPPATH=['godotsteam/sdk/public'])
-env.Append(LIBS=[steamworks_library])
+env.Append(LIBS=[
+    steamworks_library.replace(".dll", "")
+])
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=['godotsteam/'])

--- a/godotsteam.gdextension
+++ b/godotsteam.gdextension
@@ -4,12 +4,12 @@ entry_symbol = "godot_steam_init"
 [libraries]
 macos.debug = "bin/libgodotsteam.macos.template_debug.framework"
 macos.release = "bin/libgodotsteam.macos.template_release.framework"
-windows.debug.x86_64 = "bin/libgodotsteam.windows.template_debug.x86_64.dll"
-windows.release.x86_64 = "bin/libgodotsteam.windows.template_release.x86_64.dll"
+windows.debug.x86_64 = "bin/godotsteam.windows.template_debug.x86_64.dll"
+windows.release.x86_64 = "bin/godotsteam.windows.template_release.x86_64.dll"
 linux.debug.x86_64 = "bin/libgodotsteam.linux.template_debug.x86_64.so"
 linux.release.x86_64 = "bin/libgodotsteam.linux.template_release.x86_64.so"
 
 [dependencies]
 macos.universal = { "bin/libsteam_api.dylib": "" }
-windows.x86_64 = { "bin/steam_api64.lib": "" }
+windows.x86_64 = { "bin/steam_api64.dll": "" }
 linux.x86_64 = { "bin/libsteam_api.so": "" }

--- a/godotsteam.gdextension
+++ b/godotsteam.gdextension
@@ -10,3 +10,9 @@ windows.debug.x86_64 = "bin/libgodotsteam.windows.template_debug.x86_64.dll"
 windows.release.x86_64 = "bin/libgodotsteam.windows.template_release.x86_64.dll"
 linux.debug.x86_64 = "bin/libgodotsteam.linux.template_debug.x86_64.so"
 linux.release.x86_64 = "bin/libgodotsteam.linux.template_release.x86_64.so"
+
+[dependencies]
+macos.debug = { "bin/libsteam_api.dylib": "" }
+windows.x86_32 = { "bin/steam_api.lib": "" }
+windows.x86_64 = { "bin/steam_api64.lib": "" }
+linux.x86_64 = { "bin/libsteam_api.so": "" }

--- a/godotsteam.gdextension
+++ b/godotsteam.gdextension
@@ -4,15 +4,12 @@ entry_symbol = "godot_steam_init"
 [libraries]
 macos.debug = "bin/libgodotsteam.macos.template_debug.framework"
 macos.release = "bin/libgodotsteam.macos.template_release.framework"
-windows.debug.x86_32 = "bin/libgodotsteam.windows.template_debug.x86_32.dll"
-windows.release.x86_32 = "bin/libgodotsteam.windows.template_release.x86_32.dll"
 windows.debug.x86_64 = "bin/libgodotsteam.windows.template_debug.x86_64.dll"
 windows.release.x86_64 = "bin/libgodotsteam.windows.template_release.x86_64.dll"
 linux.debug.x86_64 = "bin/libgodotsteam.linux.template_debug.x86_64.so"
 linux.release.x86_64 = "bin/libgodotsteam.linux.template_release.x86_64.so"
 
 [dependencies]
-macos.debug = { "bin/libsteam_api.dylib": "" }
-windows.x86_32 = { "bin/steam_api.lib": "" }
+macos.universal = { "bin/libsteam_api.dylib": "" }
 windows.x86_64 = { "bin/steam_api64.lib": "" }
 linux.x86_64 = { "bin/libsteam_api.so": "" }


### PR DESCRIPTION
After actually trying to automate this, I noticed that it would be helpeful to
- Copy the steam library to bin automatically
- Make the gdextension depend on the steam libraries so they're copied to the build dir automatically. The syntax of dependencies is `{ "original path": "build dir path" }`, not sure if it's right on MacOS but otherwise it works.