### PR TITLE
Set an $ORIGIN rpath for the Linux editor

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -109,23 +109,6 @@ jobs:
       - name: Create Linux Bundle
         run: |
           echo "480" >> files/steam_appid.txt
-          echo -e '#!/bin/bash\n' >> files/godotsteam.sh
-          echo -e "HELP_STRING=\"-v - Run Godot with the --verbose option.\"" >> files/godotsteam.sh
-          echo -e "verbose=\"\"\n" >> files/godotsteam.sh
-          echo "while getopts hv flag" >> files/godotsteam.sh
-          echo "do" >> files/godotsteam.sh
-          echo -e "  case \"\${flag}\" in" >> files/godotsteam.sh
-          echo "    h) help=" >> files/godotsteam.sh
-          echo -e "      echo \$HELP_STRING" >> files/godotsteam.sh
-          echo "      exit" >> files/godotsteam.sh
-          echo "    ;;" >> files/godotsteam.sh
-          echo "    v) verbose=--verbose;;" >> files/godotsteam.sh
-          echo "  esac" >> files/godotsteam.sh
-          echo -e "done\n" >> files/godotsteam.sh
-          echo "export LD_LIBRARY_PATH=\"\$PWD/\"" >> files/godotsteam.sh
-          echo -n "./linux-" >> files/godotsteam.sh
-          echo -n ${{ env.ZIP_TAG }} >> files/godotsteam.sh
-          echo -n "-editor.x86_64 \$verbose" >> files/godotsteam.sh
           zip -j linux64-${{ env.ZIP_TAG }}.zip files/*
       - name: Upload bundle to release
         uses: svenstaro/upload-release-action@v2

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ By far the easiest way to use GodotSteam is to download our pre-compiled editors
 - Download the [pre-compiled editor from the Release section](https://github.com/Gramps/GodotSteam/releases) and unpack it.
 - Alternatively you can download and install the [GDNative plug-in through Godot Asset Library](https://godotengine.org/asset-library/asset/1045).
 - Everything you need should be included.
-  - Users on Linux may have issues with the libsteam_api.so, if so then [read our Linux Caveats doc](https://godotsteam.com/tutorials/linux_caveats/).
 
 At this point you can skip all the following steps and check our our tutorials to learn more about integrating Steamworks or just explore the SDK!
 

--- a/SCsub
+++ b/SCsub
@@ -8,7 +8,7 @@ env.Append(CPPPATH=["%s/sdk/public/" % module_path])
 # If compiling Linux
 if env["platform"]== "x11" or env["platform"] == "server":
 	env.Append(LIBS=["steam_api"])
-	env.Append(RPATH=["."])
+	env.Append(RPATH=env.Literal('\\$$ORIGIN'))
 	if env["bits"]=="32":
 		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux32" % module_path])
 	else: # 64 bit


### PR DESCRIPTION
This lets users skip the LD_LIBRARY_PATH workaround script.

### What is $ORIGIN

If a Linux binary (or library) has an rpath that includes `$ORIGIN`, it will look in its own directory for linked libraries. (i.e. it will act as if `LD_LIBRARY_PATH=$MYDIR` was set. All automatically!

Here's an [article](https://nehckl0.medium.com/creating-relocatable-linux-executables-by-setting-rpath-with-origin-45de573a2e98) about it.

### This PR

By setting this rpath value, you should be able to drop the Linux caveat warnings about finding libsteam_api.so and also basically drop the `godotsteam.sh` wrapper.

That said, I did not change any documentation around Linux caveats yet (I imagine a similar change should happen in the plugin branches as well first, plus maybe a release or two to give folks times to upgrade).

I also didn't remove the `godotsteam.sh` wrapper, since maybe users are used to it. But I did turn it into a just a tiny passthrough script to the editor binary (all arguments to it will get passed along).

### Testing

I tested these commands separately locally, but I did not actually test-run the CI pipeline -- I'm not super familiar with this project.