### PR TITLE
Set an $ORIGIN rpath for the Linux editor

### DIFF
--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -125,25 +125,6 @@ jobs:
       - name: Create Linux Bundle
         run: |
           echo "480" >> files/steam_appid.txt
-
-          echo -e '#!/bin/bash\n' >> files/godotsteam.sh
-          echo -e "HELP_STRING=\"-v - Run Godot with the --verbose option.\"" >> files/godotsteam.sh
-          echo -e "verbose=\"\"\n" >> files/godotsteam.sh
-          echo "while getopts hv flag" >> files/godotsteam.sh
-          echo "do" >> files/godotsteam.sh
-          echo -e "  case \"\${flag}\" in" >> files/godotsteam.sh
-          echo "    h) help=" >> files/godotsteam.sh
-          echo -e "      echo \$HELP_STRING" >> files/godotsteam.sh
-          echo "      exit" >> files/godotsteam.sh
-          echo "    ;;" >> files/godotsteam.sh
-          echo "    v) verbose=--verbose;;" >> files/godotsteam.sh
-          echo "  esac" >> files/godotsteam.sh
-          echo -e "done\n" >> files/godotsteam.sh
-          echo "export LD_LIBRARY_PATH=\"\$PWD/\"" >> files/godotsteam.sh
-          echo -n "./linux-" >> files/godotsteam.sh
-          echo -n ${{needs.env-setup.outputs.version_tag}} >> files/godotsteam.sh
-          echo -n "-editor.x86_64 \$verbose" >> files/godotsteam.sh
-
           zip -j linux64-${{needs.env-setup.outputs.zip_tag}}.zip files/*
       - name: Upload Win64 bundle artifact
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Known Issues
 By far the easiest way to use GodotSteam is to download our pre-compiled editors and templates; especially good for folks who don't want to set up the tools for compiling and just want to get going.
 - Download the [pre-compiled editor from the Release section](https://github.com/Gramps/GodotSteam/releases) and unpack it.
 - Everything you need should be included.
-  - Users on Linux may have issues with the libsteam_api.so, if so then [read our Linux Caveats doc](https://godotsteam.com/tutorials/linux_caveats).
 
 At this point you can skip all the following steps and check our our tutorials to learn more about integrating Steamworks or just explore the SDK!
 

--- a/SCsub
+++ b/SCsub
@@ -8,7 +8,7 @@ env.Append(CPPPATH=["%s/sdk/public/" % module_path])
 # If compiling Linux
 if env["platform"]== "linuxbsd" or env["platform"] == "server":
 	env.Append(LIBS=["steam_api"])
-	env.Append(RPATH=["."])
+	env.Append(RPATH=env.Literal('\\$$ORIGIN'))
 	if env['arch'] == "x86_32":
 		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux32" % module_path])
 	else: # 64 bit


### PR DESCRIPTION
This lets users skip the LD_LIBRARY_PATH workaround script.

Godot 4 version of https://github.com/Gramps/GodotSteam/pull/317