### PR TITLE
Set an $ORIGIN rpath for the Linux plugin

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -74,6 +74,7 @@ elif env['platform'] in ('linuxbsd', 'linux'):
     cpp_library += '.linux'
     env.Append(CCFLAGS=['-fPIC'])
     env.Append(CXXFLAGS=['-std=c++17'])
+    env.Append(RPATH=env.Literal('\\$$ORIGIN'))
     if env['target'] in ('debug', 'd'):
         env.Append(CCFLAGS=['-g3', '-Og'])
     else:


### PR DESCRIPTION
This helps it find libsteam_api.so

(This gdnative plugin does have the same problem the editor does -- this is how I actually originally noticed the problem.)

Related to https://github.com/Gramps/GodotSteam/pull/317