### PR TITLE
Fix GetAuthSessionTicket for SDK 1.56.

### DIFF
--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -7717,14 +7717,15 @@ void Steam::endAuthSession(uint64_t steam_id){
 }
 
 //! Get the authentication ticket data.
-Dictionary Steam::getAuthSessionTicket(){
+Dictionary Steam::getAuthSessionTicket(const String &identity_reference){
 	// Create the dictionary to use
 	Dictionary auth_ticket;
 	if(SteamUser() != NULL){
 		uint32_t ticket_size = 1024;
 		PoolByteArray buffer;
 		buffer.resize(ticket_size);
-		uint32_t id = SteamUser()->GetAuthSessionTicket(buffer.write().ptr(), ticket_size, &ticket_size);
+		const SteamNetworkingIdentity identity = networking_identities[identity_reference.utf8().get_data()];
+		uint32_t id = SteamUser()->GetAuthSessionTicket(buffer.ptrw(), ticket_size, &ticket_size, &identity);
 		// Add this data to the dictionary
 		auth_ticket["id"] = id;
 		auth_ticket["buffer"] = buffer;

--- a/godotsteam.h
+++ b/godotsteam.h
@@ -1172,7 +1172,7 @@ class Steam: public Object {
 		void cancelAuthTicket(uint32_t auth_ticket);
 		Dictionary decompressVoice(const PoolByteArray& voice, uint32 voice_size, uint32 sample_rate);
 		void endAuthSession(uint64_t steam_id);
-		Dictionary getAuthSessionTicket();
+		Dictionary getAuthSessionTicket(const String &identity_reference);
 		Dictionary getAvailableVoice();
 		void getDurationControl();
 		Dictionary getEncryptedAppTicket();


### PR DESCRIPTION
Steamworks SDK 1.56 added an identity reference to GetAuthSessionTicket.

Building with SDK 1.56 fails with:

```
modules/godotsteam/godotsteam.cpp: In member function 'Dictionary Steam::getAuthSessionTicket()':
modules/godotsteam/godotsteam.cpp:7725:91: error: no matching function for call to 'ISteamUser::GetAuthSessionTicket(unsigned char*, uint32_t&, uint32_t*)'
 7725 |   uint32_t id = SteamUser()->GetAuthSessionTicket(buffer.ptrw(), ticket_size, &ticket_size);
      |                                                                                           ^
In file included from modules/godotsteam/sdk/public/steam/steam_api.h:25,
                 from modules/godotsteam/godotsteam.h:23,
                 from modules/godotsteam/godotsteam.cpp:18:
modules/godotsteam/sdk/public/steam/isteamuser.h:130:22: note: candidate: 'virtual HAuthTicket ISteamUser::GetAuthSessionTicket(void*, int, uint32*, const SteamNetworkingIdentity*)'
  130 |  virtual HAuthTicket GetAuthSessionTicket( void *pTicket, int cbMaxTicket, uint32 *pcbTicket, const SteamNetworkingIdentity *pSteamNetworkingIdentity ) = 0;
      |                      ^~~~~~~~~~~~~~~~~~~~
modules/godotsteam/sdk/public/steam/isteamuser.h:130:22: note:   candidate expects 4 arguments, 3 provided
```

https://partner.steamgames.com/doc/api/ISteamUser#GetAuthSessionTicket says:

> The identity of the remote system that will authenticate the ticket.
> If it is peer-to-peer then the user steam ID. If it is a game server,
> then the game server steam ID may be used if it was obtained from a
> trusted 3rd party, otherwise use the IP address. If it is a service, a
> string identifier of that service if one if provided.

So it seems like this is a breaking change, and the caller now must pass
in an identity.
