### PR TITLE
Restructure exports

### DIFF
--- a/.github/workflows/build-gdextension.yml
+++ b/.github/workflows/build-gdextension.yml
@@ -188,11 +188,21 @@ jobs:
           touch win64/.gdignore
           touch win32/.gdignore
 
-          mv *.x86_64.so linux64/ || true
-          mv *.x86_32.so linux32/ || true
-          mv *.framework osx/ || true
-          mv *.x86_64.dll win64/ || true
-          mv *.dll win32/ || true
+          mv libgodotsteam.linux.template_debug.x86_32.so linux32/libgodotsteam.debug.x86_32.so || true
+          mv libgodotsteam.linux.template_debug.x86_64.so linux64/libgodotsteam.debug.x86_64.so || true
+          mv libgodotsteam.linux.template_release.x86_32.so linux32/libgodotsteam.x86_32.so || true
+          mv libgodotsteam.linux.template_release.x86_64.so linux64/libgodotsteam.x86_64.so || true
+
+          mv libgodotsteam.macos.template_debug.framework osx/libgodotsteam.debug.framework || true
+          mv libgodotsteam.macos.template_release.framework osx/libgodotsteam.framework || true
+          cp libsteam_api.dylib osx/libgodotsteam.debug.framework/ || true
+          mv libsteam_api.dylib osx/libgodotsteam.framework/ || true
+
+          mv libgodotsteam.windows.template_debug.x86_32.dll win32/libgodotsteam.debug.x86_32.dll || true
+          mv libgodotsteam.windows.template_debug.x86_64.dll win64/libgodotsteam.debug.x86_64.dll || true
+          mv libgodotsteam.windows.template_release.x86_32.dll win32/libgodotsteam.x86_32.dll || true
+          mv libgodotsteam.windows.template_release.x86_64.dll win64/libgodotsteam.x86_64.dll || true
+          
           rm -rf *.exp *.lib
           cd ../../..
 

--- a/.github/workflows/build-releases.yml
+++ b/.github/workflows/build-releases.yml
@@ -27,30 +27,30 @@ jobs:
       steamworks_sdk_repo: ${{ secrets.STEAMWORKS_SDK_REPO }}
       steamworks_sdk_repo_token: ${{ secrets.STEAMWORKS_SDK_REPO_TOKEN }}
 
-  create-release:
-    needs: [build-gdextension-release]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download Plug-in Bundle
-      uses: actions/download-artifact@v3
-      with:
-        name: gdextension
-    - name: Prepare Release
-      run: |
-        zip -r gdextension.zip *
-    - name: Upload Plug-in Bundle To Release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        file: gdextension.zip
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ inputs.godotsteam_version }}
-        release_name: ${{ inputs.release_title }}
-        prerelease: false
-        body: |
-          This the new pre-compiled plug-in for Godot 4.1! This is built on GodotSteam GDExtension 4.2.4 and linked with Steamworks SDK 1.57.
+  # create-release:
+  #   needs: [build-gdextension-release]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - name: Download Plug-in Bundle
+  #     uses: actions/download-artifact@v3
+  #     with:
+  #       name: gdextension
+  #   - name: Prepare Release
+  #     run: |
+  #       zip -r gdextension.zip *
+  #   - name: Upload Plug-in Bundle To Release
+  #     uses: svenstaro/upload-release-action@v2
+  #     with:
+  #       file: gdextension.zip
+  #       repo_token: ${{ secrets.GITHUB_TOKEN }}
+  #       tag: ${{ inputs.godotsteam_version }}
+  #       release_name: ${{ inputs.release_title }}
+  #       prerelease: false
+  #       body: |
+  #         This the new pre-compiled plug-in for Godot 4.1! This is built on GodotSteam GDExtension 4.2.4 and linked with Steamworks SDK 1.57.
 
-          **Note:** This does not work with Godot 4.0.3 or lower. Please use an earlier release for those versions.
+  #         **Note:** This does not work with Godot 4.0.3 or lower. Please use an earlier release for those versions.
 
-          Just drop the addon folder into the base of your game / project and you are good to go!
+  #         Just drop the addon folder into the base of your game / project and you are good to go!
 
-          Available for Windows, Linux, and Mac.
+  #         Available for Windows, Linux, and Mac.

--- a/godotsteam.gdextension
+++ b/godotsteam.gdextension
@@ -3,19 +3,18 @@ entry_symbol = "godotsteam_init"
 compatibility_minimum = 4.1
 
 [libraries]
-macos.debug = "osx/libgodotsteam.windows.template_debug.framework"
-macos.release = "osx/libgodotsteam.windows.template_release.framework"
-windows.debug.x86_64 = "win64/libgodotsteam.windows.template_debug.x86_64.dll"
-windows.debug.x86_32 = "win32/libgodotsteam.windows.template_debug.x86_32.dll"
-windows.release.x86_64 = "win64/libgodotsteam.windows.template_release.x86_64.dll"
-windows.release.x86_32 = "win32/libgodotsteam.windows.template_release.x86_64.dll"
-linux.debug.x86_64 = "linux64/libgodotsteam.linux.template_debug.x86_64.so"
-linux.debug.x86_32 = "linux32/libgodotsteam.linux.template_debug.x86_32.so"
-linux.release.x86_64 = "linux64/libgodotsteam.linux.template_release.x86_64.so"
-linux.release.x86_32 = "linux32/libgodotsteam.linux.template_release.x86_32.so"
+macos.debug = "osx/libgodotsteam.debug.framework"
+macos.release = "osx/libgodotsteam.framework"
+windows.debug.x86_64 = "win64/godotsteam.debug.x86_64.dll"
+windows.debug.x86_32 = "win32/godotsteam.debug.x86_32.dll"
+windows.release.x86_64 = "win64/godotsteam.x86_64.dll"
+windows.release.x86_32 = "win32/godotsteam.x86_32.dll"
+linux.debug.x86_64 = "linux64/libgodotsteam.debug.x86_64.so"
+linux.debug.x86_32 = "linux32/libgodotsteam.debug.x86_32.so"
+linux.release.x86_64 = "linux64/libgodotsteam.x86_64.so"
+linux.release.x86_32 = "linux32/libgodotsteam.x86_32.so"
 
 [dependencies]
-macos.universal = { "osx/libsteam_api.dylib": "" }
 windows.x86_64 = { "win64/steam_api64.dll": "" }
 windows.x86_32 = { "win32/steam_api.dll": "" }
 linux.x86_64 = { "linux64/libsteam_api.so": "" }


### PR DESCRIPTION
A few changes here,
- Restructure osx exports per the conversation in #357 
- Renamed all exports to match what you release with, and updated godotsteam.gdextension to match.
- Commented out the release publish stage, as you had mentioned you don't use it anyways. (This could also be changed to build every push to the gdExtension branch instead of manually too).

Opened as draft pending what we find out regarding what happens when is it exported in this state.