### PR TITLE
Added missing method for `requestEquippedProfileItems` to register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .vscode/
 bin/
 .sconsign.dblite
+
+/godotsteam/sdk/public
+/godotsteam/sdk/redistributable_bin

--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -11174,6 +11174,7 @@ void Steam::_bind_methods(){
 	ClassDB::bind_method(D_METHOD("setPersonaName", "name"), &Steam::setPersonaName);
 	ClassDB::bind_method(D_METHOD("setPlayedWith", "steam_id"), &Steam::setPlayedWith);	
 	ClassDB::bind_method(D_METHOD("setRichPresence", "key", "value"), &Steam::setRichPresence);
+	ClassDB::bind_method(D_METHOD("requestEquippedProfileItems", "steam_id"), &Steam::requestEquippedProfileItems);
 	
 	// GAME SEARCH BIND METHODS /////////////////
 	ClassDB::bind_method(D_METHOD("addGameSearchParams", "key", "values"), &Steam::addGameSearchParams);


### PR DESCRIPTION

![image](https://github.com/CoaguCo-Industries/GodotSteam/assets/16349308/e5ab5d67-a6bf-4db2-864e-3873641a95a7)


* Added missing method for `requestEquippedProfileItems` to register
* Updated `.gitignore` to prevent steam SDK from being detected as pending commits


![image](https://github.com/CoaguCo-Industries/GodotSteam/assets/16349308/2c77c9f4-7d77-454a-a9f3-fddd6962b0a6)

![image](https://github.com/CoaguCo-Industries/GodotSteam/assets/16349308/630992b3-173c-4371-8795-a361cc6dde0f)
