### PR TITLE
fix: Fix getAllLobbyData not returning all data

### DIFF
--- a/doc_classes/Steam.xml
+++ b/doc_classes/Steam.xml
@@ -1462,7 +1462,7 @@
 			<argument index="0" name="steam_lobby_id" type="int" />
 			<description>
 				Get lobby data by the lobby's ID.
-				The returned dictionary contains the following keys: [b]index (int), key (string), and value (string).[/b]
+				The returned dictionary contains dictionaries with the following keys: [b]index (int), key (string), and value (string).[/b]
 				[b]Note:[/b] This is a GodotSteam specific function.
 			</description>
 		</method>

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -3361,9 +3361,9 @@ bool Steam::setLobbyData(uint64_t steam_lobby_id, const String &key, const Strin
 
 // Get lobby data by the lobby's ID
 Dictionary Steam::getAllLobbyData(uint64_t steam_lobby_id) {
-	Dictionary data;
+	Dictionary all_data;
 	if (SteamMatchmaking() == NULL) {
-		return data;
+		return all_data;
 	}
 	CSteamID lobby_id = (uint64)steam_lobby_id;
 	int data_count = SteamMatchmaking()->GetLobbyDataCount(lobby_id);
@@ -3372,12 +3372,14 @@ Dictionary Steam::getAllLobbyData(uint64_t steam_lobby_id) {
 	for (int i = 0; i < data_count; i++) {
 		bool success = SteamMatchmaking()->GetLobbyDataByIndex(lobby_id, i, key, MAX_LOBBY_KEY_LENGTH, value, CHAT_METADATA_MAX);
 		if (success) {
+			Dictionary data;
 			data["index"] = i;
 			data["key"] = key;
 			data["value"] = value;
+			all_data[i] = data;
 		}
 	}
-	return data;
+	return all_data;
 }
 
 // Removes a metadata key from the lobby.


### PR DESCRIPTION
The current implementation does not return all data but instead overwrite the same data object.