### PR TITLE
Fix lobby_state being corrupted after calling close on the peer

### DIFF
--- a/steam_multiplayer_peer.cpp
+++ b/steam_multiplayer_peer.cpp
@@ -274,6 +274,8 @@ void SteamMultiplayerPeer::process_ping(const SteamNetworkingMessage_t *msg) {
 void SteamMultiplayerPeer::close() {
 	ERR_FAIL_COND_MSG(lobby_id == CSteamID(), "CAN'T LEAVE A LOBBY IF YOUR'E NOT IN ONE!");
 	SteamMatchmaking()->LeaveLobby(lobby_id);
+	//todo disconnect all connected peers?
+	lobby_state = LOBBY_STATE::LOBBY_STATE_NOT_CONNECTED;
 }
 
 int SteamMultiplayerPeer::get_unique_id() const {

--- a/steam_multiplayer_peer.cpp
+++ b/steam_multiplayer_peer.cpp
@@ -274,7 +274,6 @@ void SteamMultiplayerPeer::process_ping(const SteamNetworkingMessage_t *msg) {
 void SteamMultiplayerPeer::close() {
 	ERR_FAIL_COND_MSG(lobby_id == CSteamID(), "CAN'T LEAVE A LOBBY IF YOUR'E NOT IN ONE!");
 	SteamMatchmaking()->LeaveLobby(lobby_id);
-	//todo disconnect all connected peers?
 	lobby_state = LOBBY_STATE::LOBBY_STATE_NOT_CONNECTED;
 }
 


### PR DESCRIPTION
Fixes #430 
This change allows a `SteamMultiplayerPeer` that was previously connected to a lobby but left via the close method to be reused. Without this PR, the peer fails to create or join a lobby due to its internal state still indicating "connected".
Confirmed by friartruck on [Discord](https://discord.com/channels/564589037411893260/1200849339493392484/1229100264183566426) that the line added in this PR was most likely inadvertently omitted.