### PR TITLE
Fixed getConnectionRealTimeStatus checking the wrong value

### DIFF
--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -4962,7 +4962,7 @@ Dictionary Steam::getConnectionRealTimeStatus(uint32 connection, int lanes, bool
 		// Append the status
 		real_time_status["response"] = result;
 		// If the result is good, get more data
-		if (result == 0) {
+		if (result == RESULT_OK) {
 			// Get the connection status if requested
 			Dictionary connection_status;
 			if (get_status) {


### PR DESCRIPTION
Previously the value was 0, which corresponded to RESULT_NONE, instead of being 1 which corresponds to RESULT_OK.
Meaning the "realtime" status was never printed.