### PR TITLE
gdextension, add missing ISteamMatchmakingServerListResponse implementation

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -3627,8 +3627,12 @@ Dictionary Steam::getServerDetails(int server, uint64_t this_server_list_request
 		game_server["secure"] = server_item->m_bSecure;
 		game_server["last_played"] = server_item->m_ulTimeLastPlayed;
 		game_server["server_version"] = server_item->m_nServerVersion;
+		game_server["name"] = server_item->GetName();
+		game_server["game_tags"] = server_item->m_szGameTags;
+		game_server["steam_id"] = server_item->m_steamID.ConvertToUint64();
+		game_server["connection_address"] = server_item->m_NetAdr.GetConnectionAddressString();
 		// Clean up
-		delete server_item;
+		// delete server_item;
 	}
 	// Return the dictionary
 	return game_server;
@@ -3898,6 +3902,21 @@ int Steam::serverRules(const String &ip, int port) {
 		}
 	}
 	return response;
+}
+
+// A server has responded to a list request.
+void Steam::ServerResponded(HServerListRequest server_list_request, int server){
+	emit_signal("request_server_list_server_responded", (uint64)server_list_request, server);
+}
+
+// A server has failed to respond to a list request.
+void Steam::ServerFailedToRespond(HServerListRequest server_list_request, int server){
+	emit_signal("request_server_list_server_failed_to_respond", (uint64)server_list_request, server);
+}
+
+// A server list request has completed.
+void Steam::RefreshComplete(HServerListRequest server_list_request, EMatchMakingServerResponse response){
+	emit_signal("request_server_list_refresh_complete", (uint64)server_list_request, MatchMakingServerResponse(response));
 }
 
 
@@ -11591,6 +11610,11 @@ void Steam::_bind_methods() {
 	// MATCHMAKING SERVER SIGNALS ///////////////
 	ADD_SIGNAL(MethodInfo("server_responded"));
 	ADD_SIGNAL(MethodInfo("server_failed_to_respond"));
+
+	// MATCHMAKING SERVERS //////////////
+	ADD_SIGNAL(MethodInfo("request_server_list_server_responded", PropertyInfo(Variant::INT, "request_handle"), PropertyInfo(Variant::INT, "server")));
+	ADD_SIGNAL(MethodInfo("request_server_list_server_failed_to_respond", PropertyInfo(Variant::INT, "request_handle"), PropertyInfo(Variant::INT, "server")));
+	ADD_SIGNAL(MethodInfo("request_server_list_refresh_complete", PropertyInfo(Variant::INT, "request_handle"), PropertyInfo(Variant::INT, "response")));
 
 	// MUSIC SIGNALS ////////////////////////////
 	ADD_SIGNAL(MethodInfo("music_playback_status_has_changed"));

--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -3637,11 +3637,11 @@ bool Steam::isRefreshing(uint64_t this_server_list_request) {
 int Steam::pingServer(const String &ip, int port) {
 	int response = 0;
 	if (SteamMatchmakingServers() != NULL) {
-		if (ip.is_valid_ip_address()) {
-			char ip_bytes[4];
-			sscanf(ip.utf8().get_data(), "%hhu.%hhu.%hhu.%hhu", &ip_bytes[3], &ip_bytes[2], &ip_bytes[1], &ip_bytes[0]);
-			uint32_t ip4 = ip_bytes[0] | ip_bytes[1] << 8 | ip_bytes[2] << 16 | ip_bytes[3] << 24;
-			response = SteamMatchmakingServers()->PingServer(ip4, (uint16)port, ping_response);
+		SteamNetworkingIPAddr address;
+		address.Clear();
+		if (address.ParseString(ip.utf8().get_data())){
+			address.m_port = port;
+			response = SteamMatchmakingServers()->PingServer(address.GetIPv4(), address.m_port, ping_response);
 		}
 	}
 	return response;
@@ -3651,11 +3651,11 @@ int Steam::pingServer(const String &ip, int port) {
 int Steam::playerDetails(const String &ip, int port) {
 	int response = 0;
 	if (SteamMatchmakingServers() != NULL) {
-		if (ip.is_valid_ip_address()) {
-			char ip_bytes[4];
-	  		sscanf(ip.utf8().get_data(), "%hhu.%hhu.%hhu.%hhu", &ip_bytes[3], &ip_bytes[2], &ip_bytes[1], &ip_bytes[0]);
-			uint32_t ip4 = ip_bytes[0] | ip_bytes[1] << 8 | ip_bytes[2] << 16 | ip_bytes[3] << 24;
-			response = SteamMatchmakingServers()->PlayerDetails(ip4, (uint16)port, players_response);
+		SteamNetworkingIPAddr address;
+		address.Clear();
+		if (address.ParseString(ip.utf8().get_data())){
+			address.m_port = port;
+			response = SteamMatchmakingServers()->PlayerDetails(address.GetIPv4(), address.m_port, players_response);
 		}
 	}
 	return response;
@@ -3877,11 +3877,11 @@ uint64_t Steam::requestSpectatorServerList(uint32 app_id, Array filters) {
 int Steam::serverRules(const String &ip, int port) {
 	int response = 0;
 	if (SteamMatchmakingServers() != NULL) {
-		if (ip.is_valid_ip_address()) {
-			char ip_bytes[4];
-	  		sscanf(ip.utf8().get_data(), "%hhu.%hhu.%hhu.%hhu", &ip_bytes[3], &ip_bytes[2], &ip_bytes[1], &ip_bytes[0]);
-			uint32_t ip4 = ip_bytes[0] | ip_bytes[1] << 8 | ip_bytes[2] << 16 | ip_bytes[3] << 24;
-			response = SteamMatchmakingServers()->ServerRules(ip4, (uint16)port, rules_response);
+		SteamNetworkingIPAddr address;
+		address.Clear();
+		if (address.ParseString(ip.utf8().get_data())){
+			address.m_port = port;
+			response = SteamMatchmakingServers()->ServerRules(address.GetIPv4(), address.m_port, rules_response);
 		}
 	}
 	return response;

--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -3701,26 +3701,24 @@ uint64_t Steam::requestFavoritesServerList(uint32 app_id, Array filters) {
 		uint32 filter_size = filters.size();
 		MatchMakingKeyValuePair_t *filters_array = new MatchMakingKeyValuePair_t[filter_size];
 		for (uint32 i = 0; i < filter_size; i++) {
-			// Create a new filter pair to populate
-			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t();
 			// Get the key/value pair
 			Array pair = filters[i];
+
 			// Get the key from the filter pair
 			String key = (String)pair[0];
 			char *this_key = new char[256];
 			strcpy(this_key, key.utf8().get_data());
-			filter_array->m_szKey[i] = *this_key;
-			delete[] this_key;
+
 			// Get the value from the filter pair
 			String value = pair[1];
 			char *this_value = new char[256];
 			strcpy(this_value, value.utf8().get_data());
-			filter_array->m_szValue[i] = *this_value;
-			delete[] this_value;
-			// Append this to the array
+
+			// Create a new filter pair to populate
+			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t(this_key, this_value);
+			delete [] this_key;
+			delete [] this_value;
 			filters_array[i] = *filter_array;
-			// Free up the memory
-			delete filter_array;
 		}
 		server_list_request = SteamMatchmakingServers()->RequestFavoritesServerList((AppId_t)app_id, &filters_array, filter_size, server_list_response);
 		delete[] filters_array;
@@ -3735,26 +3733,24 @@ uint64_t Steam::requestFriendsServerList(uint32 app_id, Array filters) {
 		uint32 filter_size = filters.size();
 		MatchMakingKeyValuePair_t *filters_array = new MatchMakingKeyValuePair_t[filter_size];
 		for (uint32 i = 0; i < filter_size; i++) {
-			// Create a new filter pair to populate
-			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t();
 			// Get the key/value pair
 			Array pair = filters[i];
+
 			// Get the key from the filter pair
 			String key = (String)pair[0];
 			char *this_key = new char[256];
 			strcpy(this_key, key.utf8().get_data());
-			filter_array->m_szKey[i] = *this_key;
-			delete[] this_key;
+
 			// Get the value from the filter pair
 			String value = pair[1];
 			char *this_value = new char[256];
 			strcpy(this_value, value.utf8().get_data());
-			filter_array->m_szValue[i] = *this_value;
-			delete[] this_value;
-			// Append this to the array
+
+			// Create a new filter pair to populate
+			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t(this_key, this_value);
+			delete [] this_key;
+			delete [] this_value;
 			filters_array[i] = *filter_array;
-			// Free up the memory
-			delete filter_array;
 		}
 		server_list_request = SteamMatchmakingServers()->RequestFriendsServerList((AppId_t)app_id, &filters_array, filter_size, server_list_response);
 		delete[] filters_array;
@@ -3769,26 +3765,24 @@ uint64_t Steam::requestHistoryServerList(uint32 app_id, Array filters) {
 		uint32 filter_size = filters.size();
 		MatchMakingKeyValuePair_t *filters_array = new MatchMakingKeyValuePair_t[filter_size];
 		for (uint32 i = 0; i < filter_size; i++) {
-			// Create a new filter pair to populate
-			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t();
 			// Get the key/value pair
 			Array pair = filters[i];
+
 			// Get the key from the filter pair
 			String key = (String)pair[0];
 			char *this_key = new char[256];
 			strcpy(this_key, key.utf8().get_data());
-			filter_array->m_szKey[i] = *this_key;
-			delete[] this_key;
+
 			// Get the value from the filter pair
 			String value = pair[1];
 			char *this_value = new char[256];
 			strcpy(this_value, value.utf8().get_data());
-			filter_array->m_szValue[i] = *this_value;
-			delete[] this_value;
-			// Append this to the array
+
+			// Create a new filter pair to populate
+			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t(this_key, this_value);
+			delete [] this_key;
+			delete [] this_value;
 			filters_array[i] = *filter_array;
-			// Free up the memory
-			delete filter_array;
 		}
 		server_list_request = SteamMatchmakingServers()->RequestHistoryServerList((AppId_t)app_id, &filters_array, filter_size, server_list_response);
 		delete[] filters_array;
@@ -3803,26 +3797,24 @@ uint64_t Steam::requestInternetServerList(uint32 app_id, Array filters) {
 		uint32 filter_size = filters.size();
 		MatchMakingKeyValuePair_t *filters_array = new MatchMakingKeyValuePair_t[filter_size];
 		for (uint32 i = 0; i < filter_size; i++) {
-			// Create a new filter pair to populate
-			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t();
 			// Get the key/value pair
 			Array pair = filters[i];
+
 			// Get the key from the filter pair
 			String key = (String)pair[0];
 			char *this_key = new char[256];
 			strcpy(this_key, key.utf8().get_data());
-			filter_array->m_szKey[i] = *this_key;
-			delete[] this_key;
+
 			// Get the value from the filter pair
 			String value = pair[1];
 			char *this_value = new char[256];
 			strcpy(this_value, value.utf8().get_data());
-			filter_array->m_szValue[i] = *this_value;
-			delete[] this_value;
-			// Append this to the array
+
+			// Create a new filter pair to populate
+			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t(this_key, this_value);
+			delete [] this_key;
+			delete [] this_value;
 			filters_array[i] = *filter_array;
-			// Free up the memory
-			delete filter_array;
 		}
 		server_list_request = SteamMatchmakingServers()->RequestInternetServerList((AppId_t)app_id, &filters_array, filter_size, server_list_response);
 		delete[] filters_array;
@@ -3846,26 +3838,24 @@ uint64_t Steam::requestSpectatorServerList(uint32 app_id, Array filters) {
 		uint32 filter_size = filters.size();
 		MatchMakingKeyValuePair_t *filters_array = new MatchMakingKeyValuePair_t[filter_size];
 		for (uint32 i = 0; i < filter_size; i++) {
-			// Create a new filter pair to populate
-			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t();
 			// Get the key/value pair
 			Array pair = filters[i];
+
 			// Get the key from the filter pair
 			String key = (String)pair[0];
 			char *this_key = new char[256];
 			strcpy(this_key, key.utf8().get_data());
-			filter_array->m_szKey[i] = *this_key;
-			delete[] this_key;
+
 			// Get the value from the filter pair
 			String value = pair[1];
 			char *this_value = new char[256];
 			strcpy(this_value, value.utf8().get_data());
-			filter_array->m_szValue[i] = *this_value;
-			delete[] this_value;
-			// Append this to the array
+
+			// Create a new filter pair to populate
+			MatchMakingKeyValuePair_t *filter_array = new MatchMakingKeyValuePair_t(this_key, this_value);
+			delete [] this_key;
+			delete [] this_value;
 			filters_array[i] = *filter_array;
-			// Free up the memory
-			delete filter_array;
 		}
 		server_list_request = SteamMatchmakingServers()->RequestSpectatorServerList((AppId_t)app_id, &filters_array, filter_size, server_list_response);
 		delete[] filters_array;

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -42,7 +42,11 @@
 using namespace godot;
 
 
-class Steam: public Object, ISteamMatchmakingServerListResponse {
+class Steam: public Object,
+	ISteamMatchmakingServerListResponse,
+	ISteamMatchmakingPingResponse,
+	ISteamMatchmakingPlayersResponse,
+	ISteamMatchmakingRulesResponse {
 
 	GDCLASS(Steam, Object);
 
@@ -2132,9 +2136,24 @@ public:
 	uint64_t requestSpectatorServerList(uint32 app_id, Array filters);
 	int serverRules(const String &ip, int port);
 
-	void ServerResponded (HServerListRequest server_list_request, int server);
-	void ServerFailedToRespond (HServerListRequest server_list_request, int server);
+	// ISteamMatchmakingServerListResponse
+	void ServerResponded(HServerListRequest server_list_request, int server);
+	void ServerFailedToRespond(HServerListRequest server_list_request, int server);
 	void RefreshComplete (HServerListRequest server_list_request, EMatchMakingServerResponse response);
+
+	// ISteamMatchmakingPingResponse
+	void ServerResponded(gameserveritem_t &server);
+	void ServerFailedToRespond();
+
+	// ISteamMatchmakingPlayersResponse
+	void AddPlayerToList(const char *pchName, int nScore, float flTimePlayed);
+	void PlayersFailedToRespond();
+	void PlayersRefreshComplete();
+
+	// ISteamMatchmakingRulesResponse
+	void RulesResponded(const char *pchRule, const char *pchValue);
+	void RulesFailedToRespond();
+	void RulesRefreshComplete();
 
 	// Music ////////////////////////////////
 	bool musicIsEnabled();
@@ -2622,9 +2641,11 @@ private:
 	// Matchmaking Server
 	HServerListRequest server_list_request;
 	ISteamMatchmakingServerListResponse *server_list_response = this;
-	ISteamMatchmakingPingResponse *ping_response;
-	ISteamMatchmakingPlayersResponse *player_response;
-	ISteamMatchmakingRulesResponse *rules_response;
+	ISteamMatchmakingPingResponse *ping_response = this;
+	ISteamMatchmakingPlayersResponse *players_response = this;
+	ISteamMatchmakingRulesResponse *rules_response = this;
+
+	Dictionary GameServerItemToDictionary(gameserveritem_t *server_item);
 
 	// Networking Messages
 	//		std::map<int, SteamNetworkingMessage_t> network_messages;

--- a/godotsteam/godotsteam.h
+++ b/godotsteam/godotsteam.h
@@ -42,7 +42,7 @@
 using namespace godot;
 
 
-class Steam: public Object {
+class Steam: public Object, ISteamMatchmakingServerListResponse {
 
 	GDCLASS(Steam, Object);
 
@@ -2132,6 +2132,10 @@ public:
 	uint64_t requestSpectatorServerList(uint32 app_id, Array filters);
 	int serverRules(const String &ip, int port);
 
+	void ServerResponded (HServerListRequest server_list_request, int server);
+	void ServerFailedToRespond (HServerListRequest server_list_request, int server);
+	void RefreshComplete (HServerListRequest server_list_request, EMatchMakingServerResponse response);
+
 	// Music ////////////////////////////////
 	bool musicIsEnabled();
 	bool musicIsPlaying();
@@ -2617,7 +2621,7 @@ private:
 
 	// Matchmaking Server
 	HServerListRequest server_list_request;
-	ISteamMatchmakingServerListResponse *server_list_response;
+	ISteamMatchmakingServerListResponse *server_list_response = this;
 	ISteamMatchmakingPingResponse *ping_response;
 	ISteamMatchmakingPlayersResponse *player_response;
 	ISteamMatchmakingRulesResponse *rules_response;


### PR DESCRIPTION
- add an implementation
  - `ISteamMatchmakingServerListResponse`
  - `ISteamMatchmakingPingResponse`
  - `ISteamMatchmakingPlayersResponse`
  - `ISteamMatchmakingRulesResponse`
- return additional data from `Steam::getServerDetails`
- fix wrong ip conversions for requests
  - `Steam::pingServer`
  - `Steam::playerDetails`
  - `Steam::serverRules`