### PR TITLE
fix(input): implement `enableActionEventCallbacks` and improve `input_action_event` signal

### DIFF
--- a/doc_classes/Steam.xml
+++ b/doc_classes/Steam.xml
@@ -1016,6 +1016,12 @@
 				Triggers a [signal Steam.leaderboard_scores_downloaded] callback.
 			</description>
 		</method>
+		<method name="enableActionEventCallbacks">
+			<return type="void" />
+			<description>
+				Enable the [signal Steam.input_action_event] callback.
+			</description>
+		</method>
 		<method name="enableDeviceCallbacks">
 			<return type="void" />
 			<description>

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -2859,13 +2859,16 @@ void Steam::enableDeviceCallbacks() {
 // Enable SteamInputActionEvent_t callbacks. Directly calls your callback function for lower latency than standard Steam callbacks.
 // Supports one callback at a time.
 // Note: this is called within either SteamInput()->RunFrame or by SteamAPI_RunCallbacks
-//void Steam::enableActionEventCallbacks() {
-//	if (SteamInput() != NULL) {
-//		// Too dumb to figure out how to pass this function to the pointer
-//		SteamInputActionEventCallbackPointer *this_action_callback = &Steam::inputActionEventCallback;
-//		SteamInput()->EnableActionEventCallbacks(*this_action_callback);
-//	}
-//}
+void Steam::enableActionEventCallbacks() {
+	if (SteamInput() == NULL) {
+		return;
+	}
+
+	SteamInputActionEventCallbackPointer callback = [](SteamInputActionEvent_t *call_data)
+		{ Steam::get_singleton()->inputActionEventCallback(call_data); };
+
+	SteamInput()->EnableActionEventCallbacks(callback);
+}
 
 // Get a local path to a PNG file for the provided origin's glyph.
 String Steam::getGlyphPNGForActionOrigin(InputActionOrigin origin, InputGlyphSize size, uint32 flags) {
@@ -10837,7 +10840,7 @@ void Steam::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("waitForData", "wait_forever", "timeout"), &Steam::waitForData);
 	ClassDB::bind_method("newDataAvailable", &Steam::newDataAvailable);
 	ClassDB::bind_method("enableDeviceCallbacks", &Steam::enableDeviceCallbacks);
-	//	ClassDB::bind_method("enableActionEventCallbacks", &Steam::enableActionEventCallbacks);
+	ClassDB::bind_method("enableActionEventCallbacks", &Steam::enableActionEventCallbacks);
 	ClassDB::bind_method(D_METHOD("getGlyphPNGForActionOrigin", "origin", "size", "flags"), &Steam::getGlyphPNGForActionOrigin);
 	ClassDB::bind_method(D_METHOD("getGlyphSVGForActionOrigin", "origin", "flags"), &Steam::getGlyphSVGForActionOrigin);
 	ClassDB::bind_method(D_METHOD("triggerVibrationExtended", "input_handle", "left_speed", "right_speed", "left_trigger_speed", "right_trigger_speed"), &Steam::triggerVibrationExtended);

--- a/godotsteam.h
+++ b/godotsteam.h
@@ -1998,7 +1998,7 @@ public:
 	void deactivateActionSetLayer(uint64_t input_handle, uint64_t action_set_handle);
 	void deactivateAllActionSetLayers(uint64_t input_handle);
 	void enableDeviceCallbacks();
-	//		void enableActionEventCallbacks();
+	void enableActionEventCallbacks();
 	uint64_t getActionSetHandle(const String &action_set_name);
 	InputActionOrigin getActionOriginFromXboxOrigin(uint64_t input_handle, int origin);
 	Array getActiveActionSetLayers(uint64_t input_handle);


### PR DESCRIPTION
This PR adds support for the `Steam.input_action_event` signal by implementing the `enableActionEventCallbacks` method. I don't have much experience with C++, so it's possible there's a better solution for assigning the `SteamInputActionEventCallbackPointer` function pointer to the `Steam::inputActionEventCallback` method.

I've also changed the `Steam.input_action_event` signal API to utilize more parameters, simplifying how the action state is read by consumers. The call data that steam passes makes use of a tagged union, so only one type of event data will be populated at a time.

**@Gramps:** If approved, would I need to open this PR against the other main branches like `gdextension` or do those get automatically updated once `godot4` is merged?

#### Testing

I was able to test this locally (MacOS + PS4 controller) by compiling the PR and then loading up a demo project where Steam input events are read. Using [Steam's implementation notes](https://partner.steamgames.com/doc/features/steam_controller/getting_started_for_devs) I was able to verify that both digital and analog actions result in the signal being invoked with the correct arguments. I haven't done extensive testing here so I'd welcome additional testing.