### PR TITLE
fix: missing get_lobby_id getter in steam multiplayer peer

### DIFF
--- a/steam_multiplayer_peer.cpp
+++ b/steam_multiplayer_peer.cpp
@@ -33,6 +33,7 @@ void SteamMultiplayerPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_lobby", "lobby_type", "max_players"), &SteamMultiplayerPeer::create_lobby, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("connect_lobby", "lobby_id"), &SteamMultiplayerPeer::join_lobby);
 	ClassDB::bind_method(D_METHOD("get_state"), &SteamMultiplayerPeer::get_state);
+	ClassDB::bind_method(D_METHOD("get_lobby_id"), &SteamMultiplayerPeer::get_lobby_id);
 	ClassDB::bind_method(D_METHOD("collect_debug_data"), &SteamMultiplayerPeer::collect_debug_data);
 
 	ClassDB::bind_method(D_METHOD("get_no_nagle"), &SteamMultiplayerPeer::get_no_nagle);


### PR DESCRIPTION
Nothing special, just a one-liner with the missing "get_lobby_id" getter which one needs to call `void Steam::activateGameOverlayInviteDialog(uint64_t steam_id)` .

Fixes #466 