### PR TITLE
Fix unexpected bahavior when initializing a dictionary value

### DIFF
--- a/godotsteam/godotsteam.cpp
+++ b/godotsteam/godotsteam.cpp
@@ -7535,7 +7535,8 @@ Dictionary Steam::getAchievement(String name) {
 		achieve["ret"] = false;
 	}
 	else {
-		achieve["ret"] = SteamUserStats()->GetAchievement(name.utf8().get_data(), &achieved);
+		bool ret = SteamUserStats()->GetAchievement(name.utf8().get_data(), &achieved);
+		achieve["ret"] = ret;
 	}
 	achieve["achieved"] = achieved;
 	return achieve;
@@ -7549,7 +7550,8 @@ Dictionary Steam::getAchievementAchievedPercent(String name) {
 		achieve["ret"] = false;
 	}
 	else {
-		achieve["ret"] = SteamUserStats()->GetAchievementAchievedPercent(name.utf8().get_data(), &percent);
+		bool ret = SteamUserStats()->GetAchievementAchievedPercent(name.utf8().get_data(), &percent);
+		achieve["ret"] = ret;
 	}
 	achieve["percent"] = percent;
 	return achieve;


### PR DESCRIPTION
Make a copy of returned boolean to ensure a proper behavior.

Sometimes, a dictionary value is assigned with null / freed memory. I was not able to dig deep enough into Godot's Dictionary implementation, but it must be some nitty-gritty stuff related to `operator[]` internals.

Fixes #474 