### PR TITLE
When no p2p packet are available return -1 when calling getAvailableP2PPacketSize

### DIFF
--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -3762,7 +3762,7 @@ Dictionary Steam::getP2PSessionState(uint64_t remote_steam_id) {
 uint32_t Steam::getAvailableP2PPacketSize(int channel) {
 	ERR_FAIL_COND_V_MSG(SteamNetworking() == NULL, 0, "[STEAM] Game Server class not found when calling: getAvailableP2PPacketSize");
 	uint32_t message_size = 0;
-	return (SteamNetworking()->IsP2PPacketAvailable(&message_size, channel)) ? message_size : 0;
+	return (SteamNetworking()->IsP2PPacketAvailable(&message_size, channel)) ? message_size : -1;
 }
 
 // Reads in a packet that has been sent from another user via SendP2PPacket.

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -3758,7 +3758,7 @@ Dictionary Steam::getP2PSessionState(uint64_t remote_steam_id) {
 	return result;
 }
 
-// Calls IsP2PPacketAvailable() under the hood, returns the size of the available packet or zero if there is no such packet.
+// Calls IsP2PPacketAvailable() under the hood, returns the size of the available packet or -1 if there is no such packet.
 uint32_t Steam::getAvailableP2PPacketSize(int channel) {
 	ERR_FAIL_COND_V_MSG(SteamNetworking() == NULL, 0, "[STEAM] Game Server class not found when calling: getAvailableP2PPacketSize");
 	uint32_t message_size = 0;


### PR DESCRIPTION
Steam allow to send packet of size 0, currently the fact that this is returning 0 when no packet is available prevent handling such packet.

Most likely sending a 0 length packet is due to an error, but instead of crashing, currently the network code stop receiving packet (since we nee to check if packet_size > 0 to process the next packet)

NOTE:
- This is a breaking change, I don't know how those are handled in the project.