### PR TITLE
make it load dynamic and not crash

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -5,38 +5,4 @@ module_path = Dir('.').srcnode().abspath
 
 env.Append(CPPPATH=["%s/sdk/public/" % module_path])
 
-# If compiling Linux
-if env["platform"]== "linuxbsd" or env["platform"] == "server":
-	env.Append(LIBS=["steam_api"])
-	env.Append(RPATH=env.Literal('\\$$ORIGIN'))
-	if env['arch'] == "x86_32":
-		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux32" % module_path])
-	else: # 64 bit
-		env.Append(LIBPATH=["%s/sdk/redistributable_bin/linux64" % module_path])
-
-# If compiling Windows
-elif env["platform"] == "windows":
-	# Mostly VisualStudio
-	if env["CC"] == "cl":
-		if env['arch'] == "x86_32":
-			env.Append(LINKFLAGS=["steam_api.lib"])
-			env.Append(LIBPATH=["%s/sdk/redistributable_bin" % module_path])
-		else: # 64 bit
-			env.Append(LINKFLAGS=["steam_api64.lib"])
-			env.Append(LIBPATH=["%s/sdk/redistributable_bin/win64" % module_path])
-	
-	# Mostly "GCC"
-	else:
-		if env['arch'] == "x86_32":
-			env.Append(LIBS=["steam_api"])
-			env.Append(LIBPATH=["%s/sdk/redistributable_bin" % module_path])
-		else: # 64 bit
-			env.Append(LIBS=["steam_api64"])
-			env.Append(LIBPATH=["%s/sdk/redistributable_bin/win64" % module_path])
-
-# If compiling OSX
-elif env["platform"] == "macos":
-	env.Append(LIBS=["steam_api"])
-	env.Append(LIBPATH=['%s/sdk/redistributable_bin/osx' % module_path])
-
 env.add_source_files(env.modules_sources,"*.cpp")

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -16,6 +16,256 @@
 
 Steam *Steam::singleton = NULL;
 
+void *steam_library_handle = nullptr;
+
+typedef ESteamAPIInitResult (*SteamInternal_SteamAPI_Init_t)(const char*, SteamErrMsg*);
+SteamInternal_SteamAPI_Init_t pointer_SteamInternal_SteamAPI_Init = nullptr;
+
+typedef HSteamUser (*SteamAPI_GetHSteamUser_t)();
+SteamAPI_GetHSteamUser_t pointer_SteamAPI_GetHSteamUser = nullptr;
+
+typedef bool (*SteamAPI_IsSteamRunning_t)();
+SteamAPI_IsSteamRunning_t pointer_SteamAPI_IsSteamRunning = nullptr;
+
+typedef void (*SteamAPI_RegisterCallResult_t)(class CCallbackBase *pCallback, SteamAPICall_t hAPICall);
+SteamAPI_RegisterCallResult_t pointer_SteamAPI_RegisterCallResult = nullptr;
+
+typedef void (*SteamAPI_RegisterCallback_t)(class CCallbackBase *pCallback, int iCallback);
+SteamAPI_RegisterCallback_t pointer_SteamAPI_RegisterCallback = nullptr;
+
+typedef void (*SteamAPI_RunCallbacks_t)();
+SteamAPI_RunCallbacks_t pointer_SteamAPI_RunCallbacks = nullptr;
+
+typedef void (*SteamAPI_UnregisterCallResult_t)(class CCallbackBase *pCallback, SteamAPICall_t hAPICall);
+SteamAPI_UnregisterCallResult_t pointer_SteamAPI_UnregisterCallResult = nullptr;
+
+typedef void (*SteamAPI_UnregisterCallback_t)(class CCallbackBase *pCallback);
+SteamAPI_UnregisterCallback_t pointer_SteamAPI_UnregisterCallback = nullptr;
+
+typedef HSteamUser (*SteamGameServer_GetHSteamUser_t)();
+SteamGameServer_GetHSteamUser_t pointer_SteamGameServer_GetHSteamUser = nullptr;
+
+typedef void* (*SteamInternal_ContextInit_t)(void*);
+SteamInternal_ContextInit_t pointer_SteamInternal_ContextInit = nullptr;
+
+typedef bool (*SteamAPI_RestartAppIfNecessary_t)(uint32);
+SteamAPI_RestartAppIfNecessary_t pointer_SteamAPI_RestartAppIfNecessary = nullptr;
+
+void load_steam_dll() {
+	String path;
+ 	if (OS::get_singleton()->has_feature("linuxbsd")) {
+ 		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.so");
+ 		if (!FileAccess::exists(path)) {
+ 			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../lib").path_join("libsteam_api.so");
+ 			if (!FileAccess::exists(path)) {
+				ERR_PRINT("Cannot find " + path);
+ 				return;
+ 			}
+ 		}
+ 	} else if (OS::get_singleton()->has_feature("windows")) {
+ 		if (OS::get_singleton()->has_feature("64")) {
+ 			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api64.dll");
+ 		} else {
+ 			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api.dll");
+ 		}
+ 		if (!FileAccess::exists(path)) {
+			ERR_PRINT("Cannot find " + path);
+ 			return;
+ 		}
+ 	} else if (OS::get_singleton()->has_feature("macos")) {
+ 		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.dylib");
+ 		if (!FileAccess::exists(path)) {
+ 			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../Frameworks").path_join("libsteam_api.dylib");
+ 			if (!FileAccess::exists(path)) {
+				ERR_PRINT("Cannot find " + path);
+ 				return;
+ 			}
+ 		}
+ 	} else {
+		ERR_PRINT("Steam not supported on this platform");
+ 		return;
+ 	}
+
+ 	Error err = OS::get_singleton()->open_dynamic_library(path, steam_library_handle);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot open Steam dll");
+ 		steam_library_handle = nullptr;
+ 		return;
+ 	}
+ 	print_verbose("Loaded SteamAPI library");
+
+	// Load init function
+ 	void *symbol_handle = nullptr;
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamInternal_SteamAPI_Init", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamInternal_SteamAPI_Init");
+		return;
+ 	} else {
+ 		pointer_SteamInternal_SteamAPI_Init = reinterpret_cast<ESteamAPIInitResult (*)(const char*, SteamErrMsg*)>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_GetHSteamUser function
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_GetHSteamUser", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_GetHSteamUser");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_GetHSteamUser = reinterpret_cast<HSteamUser (*)()>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_IsSteamRunning function
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_IsSteamRunning", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_IsSteamRunning");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_IsSteamRunning = reinterpret_cast<bool (*)()>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_RegisterCallResult function
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_RegisterCallResult", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_RegisterCallResult");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_RegisterCallResult = reinterpret_cast<void (*)(class CCallbackBase*, SteamAPICall_t)>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_RegisterCallback function
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_RegisterCallback", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_RegisterCallback");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_RegisterCallback = reinterpret_cast<void (*)(class CCallbackBase*, int)>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_RunCallbacks function
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_RunCallbacks", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_RunCallbacks");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_RunCallbacks = reinterpret_cast<void (*)()>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_UnregisterCallResult
+ 	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_UnregisterCallResult", symbol_handle, true);
+ 	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_UnregisterCallResult");
+		return;
+ 	} else {
+ 		pointer_SteamAPI_UnregisterCallResult = reinterpret_cast<void (*)(class CCallbackBase*, SteamAPICall_t)>(symbol_handle);
+ 	}
+
+	// Load SteamAPI_UnregisterCallback
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_UnregisterCallback", symbol_handle, true);
+	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_UnregisterCallback");
+		return;
+	} else {
+		pointer_SteamAPI_UnregisterCallback = reinterpret_cast<void (*)(class CCallbackBase*)>(symbol_handle);
+	}
+
+	// Load SteamGameServer_GetHSteamUser
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamGameServer_GetHSteamUser", symbol_handle, true);
+	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamGameServer_GetHSteamUser");
+		return;
+	} else {
+		pointer_SteamGameServer_GetHSteamUser = reinterpret_cast<HSteamUser (*)()>(symbol_handle);
+	}
+
+	// Load SteamInternal_ContextInit
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamInternal_ContextInit", symbol_handle, true);
+	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamInternal_ContextInit");
+		return;
+	} else {
+		pointer_SteamInternal_ContextInit = reinterpret_cast<void *(*)(void*)>(symbol_handle);
+	}
+
+	// Load SteamAPI_RestartAppIfNecessary
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_RestartAppIfNecessary", symbol_handle, true);
+	if (err != OK) {
+		ERR_PRINT("Cannot load function SteamAPI_RestartAppIfNecessary");
+		return;
+	} else {
+		pointer_SteamAPI_RestartAppIfNecessary = reinterpret_cast<bool (*)(uint32)>(symbol_handle);
+	}
+ }
+
+S_API ESteamAPIInitResult S_CALLTYPE SteamInternal_SteamAPI_Init( const char *pszInternalCheckInterfaceVersions, SteamErrMsg *pOutErrMsg ) {
+	if (pointer_SteamInternal_SteamAPI_Init != nullptr) {
+		return pointer_SteamInternal_SteamAPI_Init(pszInternalCheckInterfaceVersions, pOutErrMsg);
+	}
+	return ESteamAPIInitResult::k_ESteamAPIInitResult_FailedGeneric;
+}
+
+S_API HSteamUser S_CALLTYPE SteamAPI_GetHSteamUser() {
+	if (pointer_SteamAPI_GetHSteamUser != nullptr) {
+		return pointer_SteamAPI_GetHSteamUser();
+	}
+	return 0;
+}
+
+S_API bool S_CALLTYPE SteamAPI_IsSteamRunning() {
+	if (pointer_SteamAPI_IsSteamRunning != nullptr) {
+		return pointer_SteamAPI_IsSteamRunning();
+	}
+	return false;
+}
+
+S_API void SteamAPI_RegisterCallResult S_CALLTYPE ( class CCallbackBase *pCallback, SteamAPICall_t hAPICall ) {
+	if (pointer_SteamAPI_RegisterCallResult != nullptr) {
+		pointer_SteamAPI_RegisterCallResult(pCallback, hAPICall);
+	}
+}
+
+S_API void S_CALLTYPE SteamAPI_RegisterCallback( class CCallbackBase *pCallback, int iCallback ) {
+	if (pointer_SteamAPI_RegisterCallback != nullptr) {
+		pointer_SteamAPI_RegisterCallback(pCallback, iCallback);
+	}
+}
+
+S_API void S_CALLTYPE SteamAPI_RunCallbacks() {
+	if (pointer_SteamAPI_RunCallbacks != nullptr) {
+		pointer_SteamAPI_RunCallbacks();
+	}
+}
+
+S_API void S_CALLTYPE SteamAPI_UnregisterCallResult( class CCallbackBase *pCallback, SteamAPICall_t hAPICall ) {
+	if (pointer_SteamAPI_UnregisterCallResult != nullptr) {
+		pointer_SteamAPI_UnregisterCallResult(pCallback, hAPICall);
+	}
+}
+
+S_API void S_CALLTYPE SteamAPI_UnregisterCallback( class CCallbackBase *pCallback ) {
+	if (pointer_SteamAPI_UnregisterCallback != nullptr) {
+		pointer_SteamAPI_UnregisterCallback(pCallback);
+	}
+}
+
+S_API HSteamUser S_CALLTYPE SteamGameServer_GetHSteamUser() {
+	if (pointer_SteamGameServer_GetHSteamUser != nullptr) {
+		return pointer_SteamGameServer_GetHSteamUser();
+	}
+	return 0;
+}
+
+S_API void *S_CALLTYPE SteamInternal_ContextInit( void *pContextInitData ) {
+	if (pointer_SteamInternal_ContextInit != nullptr) {
+		return pointer_SteamInternal_ContextInit(pContextInitData);
+	}
+	return nullptr;
+}
+
+S_API bool S_CALLTYPE SteamAPI_RestartAppIfNecessary( uint32 unOwnAppID ) {
+	if (pointer_SteamAPI_RestartAppIfNecessary != nullptr) {
+		return pointer_SteamAPI_RestartAppIfNecessary(unOwnAppID);
+	}
+	return false;
+}
 
 Steam::Steam() :
 	// Apps
@@ -195,6 +445,9 @@ Steam::Steam() :
 	callbackGetOPFSettingsResult(this, &Steam::get_opf_settings_result),
 	callbackGetVideoResult(this, &Steam::get_video_result)
 {
+ 	print_verbose("Loading SteamAPI library");
+	load_steam_dll();
+ 	print_verbose("Finished loading SteamAPI library");
 	is_init_success = false;
 	singleton = this;
 	were_callbacks_embedded = false;
@@ -507,7 +760,7 @@ Dictionary Steam::steamInitEx(bool retrieve_stats, uint32_t app_id, bool embed_c
 
 // Shuts down the Steamworks API, releases pointers and frees memory.
 void Steam::steamShutdown() {
-	SteamAPI_Shutdown();
+	//SteamAPI_Shutdown();
 
 	// If callbacks were connected internally
 	if (were_callbacks_embedded) {
@@ -6688,7 +6941,7 @@ PackedInt64Array Steam::getGlobalStatIntHistory(const String &name) {
 	PackedInt64Array history_ints;
 	ERR_FAIL_COND_V_MSG(SteamUserStats() == NULL, history_ints, "[STEAM] User Stats class not found when calling: getGlobalStatIntHistory");
 	uint32 history_size = 0;
-	int64 *history;
+	int64 *history = nullptr;
 	int32 histories = SteamUserStats()->GetGlobalStatHistory(name.utf8().get_data(), history, history_size);
 	for (int32 i = 0; i < histories; i++) {
 		history_ints.append(history[i]);
@@ -6701,7 +6954,7 @@ PackedFloat64Array Steam::getGlobalStatFloatHistory(const String &name) {
 	PackedFloat64Array history_floats;
 	ERR_FAIL_COND_V_MSG(SteamUserStats() == NULL, history_floats, "[STEAM] User Stats class not found when calling: getGlobalStatFloatHistory");
 	uint32 history_size = 0;
-	double *history;
+	double *history = nullptr;
 	int32 histories = SteamUserStats()->GetGlobalStatHistory(name.utf8().get_data(), history, history_size);
 	for (int32 i = 0; i < histories; i++) {
 		history_floats.append(history[i]);

--- a/godotsteam.h
+++ b/godotsteam.h
@@ -1022,20 +1022,20 @@ private:
 
 	// Matchmaking Server
 	// ISteamMatchmakingServerListResponse
-	void ServerResponded(HServerListRequest list_request_handle, int server);
-	void ServerFailedToRespond(HServerListRequest list_request_handle, int server);
-	void RefreshComplete (HServerListRequest list_request_handle, EMatchMakingServerResponse response);
+	void ServerResponded(HServerListRequest list_request_handle, int server) override;
+	void ServerFailedToRespond(HServerListRequest list_request_handle, int server) override;
+	void RefreshComplete (HServerListRequest list_request_handle, EMatchMakingServerResponse response) override;
 	// ISteamMatchmakingPingResponse
-	void ServerResponded(gameserveritem_t &server);
-	void ServerFailedToRespond();
+	void ServerResponded(gameserveritem_t &server) override;
+	void ServerFailedToRespond() override;
 	// ISteamMatchmakingPlayersResponse
-	void AddPlayerToList(const char *player_name, int score, float time_played);
-	void PlayersFailedToRespond();
-	void PlayersRefreshComplete();
+	void AddPlayerToList(const char *player_name, int score, float time_played) override;
+	void PlayersFailedToRespond() override;
+	void PlayersRefreshComplete() override;
 	// ISteamMatchmakingRulesResponse
-	void RulesResponded(const char *rule, const char *value);
-	void RulesFailedToRespond();
-	void RulesRefreshComplete();
+	void RulesResponded(const char *rule, const char *value) override;
+	void RulesFailedToRespond() override;
+	void RulesRefreshComplete() override;
 
 	// Music
 	STEAM_CALLBACK(Steam, music_playback_status_has_changed, PlaybackStatusHasChanged_t, callbackMusicPlaybackStatusHasChanged);


### PR DESCRIPTION
Right now it will crash at runtime unless you have the dll. With this change, it will work and not crash, because:
- It adds a middleware that implements the functions.
- At constructor time, it loads the dll, if its loaded, it loads the functions
- When someone calls a function, it uses the middleware, and if the function is loaded, it calls that.

This way it won't crash at runtime, and it will run the same way as before.

Thanks to @fwsGonzo for the idea and how to do this middleware implementation.