### PR TITLE
Convert BGRA image format from CEF to RGBA format for Godot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,6 @@ Thanks for contributing to the GodotSteam source code! We only have a few minor 
 1. Use camel-case for any new Steam function names; ie. newSteamFunction(), you can use snake_case for anything else.
 2. Use all lower-case, underscore-separated names for all variables and arguments; ie. new_argument, new_variable
 3. Make sure your new function names, variables, and argument clearly state what they are.
-4. Make sure your code compiles before submitting a pull-request.  You may want to use `scons platform=[your platform] production=yes target=editot` to test your editor build.
+4. Make sure your code compiles before submitting a pull-request.  You may want to use `scons platform=[your platform] production=yes target=editor` to test your editor build.
 
 So far that's it!  Thanks again for helping make the project useful for the community!

--- a/doc_classes/Steam.xml
+++ b/doc_classes/Steam.xml
@@ -7368,7 +7368,7 @@
 				Called when a browser surface has a pending paint. This is where you get the actual image data to render to the screen.
 				The returned dictionary contains the following keys:
 				[codeblock]
-				┠╴bgra (string)
+				┠╴rgba (string)
 				┠╴wide (int)
 				┠╴tall (int)
 				┠╴update_x (int)

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -7657,7 +7657,24 @@ void Steam::html_needs_paint(HTML_NeedsPaint_t *call_data) {
 	browser_handle = call_data->unBrowserHandle;
 	// Create dictionary to bypass Godot argument limit
 	Dictionary page_data;
-	page_data["bgra"] = call_data->pBGRA;
+
+	// Get image dimensions and size
+	unsigned int pixel_count = call_data->unWide * call_data->unTall;
+	// Create RGBA buffer
+	PackedByteArray rgba_data;
+	rgba_data.resize(pixel_count * 4);
+	const uint8_t *bgra = (const uint8_t *)call_data->pBGRA;
+	uint8_t *rgba = rgba_data.ptrw();
+	
+	// Loop to swap B and R channels for the image
+	for (unsigned int i = 0; i < pixel_count; i++) {
+		rgba[i * 4 + 0] = bgra[i * 4 + 2]; // R = B
+		rgba[i * 4 + 1] = bgra[i * 4 + 1]; // G = G
+		rgba[i * 4 + 2] = bgra[i * 4 + 0]; // B = R
+		rgba[i * 4 + 3] = bgra[i * 4 + 3]; // A = A
+	}
+	
+	page_data["rgba"] = rgba_data;
 	page_data["wide"] = call_data->unWide;
 	page_data["tall"] = call_data->unTall;
 	page_data["update_x"] = call_data->unUpdateX;


### PR DESCRIPTION
This PR modifies the `html_needs_paint` function of the `Steam` class to convert the image format that is created from CEF, from BGRA format to RGBA format, so that the Godot engine is able to work with the payload when drawing the HTML Surface to either a Sprite or a Texture. 

It also modifies the Dictionary payload to better represent this new format so instead of returning a `bgra` property it will now return an `rgba` property so the Steam.xml documentation has been updated to reflect that change.