### PR TITLE
getItemDefinitionProperty - change return type to Dictionary

### DIFF
--- a/doc_classes/Steam.xml
+++ b/doc_classes/Steam.xml
@@ -2572,9 +2572,9 @@
 				The returned dictionary contains the following keys:
 				[codeblock]
 				┠╴property (string)
-				┠╴result (bool)
+				┠╴success (bool)
 				[/codeblock]
-				The "result" flag is true on success; false indicating that the item definitions have not been loaded from the server, or no item definitions exist for the current application, or the property name was not found in the item definition.
+				The "success" flag is true on success; false indicating that the item definitions have not been loaded from the server, or no item definitions exist for the current application, or the property name was not found in the item definition.
 			</description>
 		</method>
 		<method name="getItemDownloadInfo">

--- a/doc_classes/Steam.xml
+++ b/doc_classes/Steam.xml
@@ -2569,6 +2569,12 @@
 				Note that some properties (for example, "name") may be localized and will depend on the current Steam language settings; see [method Steam.getCurrentGameLanguage]. Property names are always ASCII alphanumeric and underscores.
 				Pass in NULL for name to get a comma-separated list of available property names.
 				[b]Note:[/b] Call [method Steam.loadItemDefinitions] first, to ensure that items are ready to be used before calling [method Steam.getItemDefinitionProperty].
+				The returned dictionary contains the following keys:
+				[codeblock]
+				┠╴property (string)
+				┠╴result (bool)
+				[/codeblock]
+				The "result" flag is true on success; false indicating that the item definitions have not been loaded from the server, or no item definitions exist for the current application, or the property name was not found in the item definition.
 			</description>
 		</method>
 		<method name="getItemDownloadInfo">

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -2689,14 +2689,14 @@ int32 Steam::getAllItems() {
 Dictionary Steam::getItemDefinitionProperty(uint32 definition, const String& name) {
 	Dictionary item_definition;
 	item_definition["property"] = "";
-	item_definition["result"] = false;
+	item_definition["success"] = false;
 	ERR_FAIL_COND_V_MSG(SteamInventory() == NULL, item_definition, "[STEAM] Inventory class not found when calling: getItemDefinitionProperty");
 	char buffer[STEAM_BUFFER_SIZE];
 	uint32 buffer_size = std::size(buffer);
-	bool steam_result = SteamInventory()->GetItemDefinitionProperty(definition, name.utf8().get_data(), buffer, &buffer_size);
+	bool steam_success = SteamInventory()->GetItemDefinitionProperty(definition, name.utf8().get_data(), buffer, &buffer_size);
 	String property = String::utf8(buffer, buffer_size);
 	item_definition["property"] = property;
-	item_definition["result"] = steam_result;
+	item_definition["success"] = steam_success;
 	return item_definition;
 }
 

--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -2686,13 +2686,18 @@ int32 Steam::getAllItems() {
 }
 
 // Gets a string property from the specified item definition.  Gets a property value for a specific item definition.
-String Steam::getItemDefinitionProperty(uint32 definition, const String &name) {
-	ERR_FAIL_COND_V_MSG(SteamInventory() == NULL, "", "[STEAM] Inventory class not found when calling: getItemDefinitionProperty");
+Dictionary Steam::getItemDefinitionProperty(uint32 definition, const String& name) {
+	Dictionary item_definition;
+	item_definition["property"] = "";
+	item_definition["result"] = false;
+	ERR_FAIL_COND_V_MSG(SteamInventory() == NULL, item_definition, "[STEAM] Inventory class not found when calling: getItemDefinitionProperty");
 	char buffer[STEAM_BUFFER_SIZE];
 	uint32 buffer_size = std::size(buffer);
-	SteamInventory()->GetItemDefinitionProperty(definition, name.utf8().get_data(), buffer, &buffer_size);
+	bool steam_result = SteamInventory()->GetItemDefinitionProperty(definition, name.utf8().get_data(), buffer, &buffer_size);
 	String property = String::utf8(buffer, buffer_size);
-	return property;
+	item_definition["property"] = property;
+	item_definition["result"] = steam_result;
+	return item_definition;
 }
 
 // After a successful call to RequestPrices, you can call this method to get the pricing for a specific item definition.

--- a/godotsteam.h
+++ b/godotsteam.h
@@ -351,7 +351,7 @@ public:
 	int32 exchangeItems(const PackedInt64Array output_items, const PackedInt32Array output_quantity, const PackedInt64Array input_items, const PackedInt32Array input_quantity);
 	int32 generateItems(const PackedInt64Array items, const PackedInt32Array quantity);
 	int32 getAllItems();
-	String getItemDefinitionProperty(uint32 definition, const String &name);
+	Dictionary getItemDefinitionProperty(uint32 definition, const String &name);
 	int32 getItemsByID(const PackedInt64Array id_array);
 	Dictionary getItemPrice(uint32 definition);
 	Array getItemsWithPrices();


### PR DESCRIPTION
As discussed over on Discord, changing the return type to that of a `Dictionary`.
This allows us to still get the property String, but also the success flag that is passed from Steam.