### PR TITLE
Fixes compilation errors on 4.5+

### DIFF
--- a/godotsteam.cpp
+++ b/godotsteam.cpp
@@ -3299,7 +3299,7 @@ static std::vector<MatchMakingKeyValuePair_t> filters_array_to_vector(const Arra
 		Array pair = filters[i];
 		String key = pair[0];
 		String value = pair[1];
-		filters_array[i] = MatchMakingKeyValuePair_t(key.utf8(), value.utf8());
+		filters_array[i] = MatchMakingKeyValuePair_t(key.utf8().get_data(), value.utf8().get_data());
 	}
 	return filters_array;
 }
@@ -5609,7 +5609,7 @@ bool Steam::initWorkshopForGameServer(uint32_t workshop_depot_id, String folder)
 	bool initialized_workshop = false;
 	ERR_FAIL_COND_V_MSG(SteamUGC() == NULL, initialized_workshop, "[STEAM] UGC class not found when calling: initWorkshopForGameServer");
 	DepotId_t workshop = (uint32_t)workshop_depot_id;
-	initialized_workshop = SteamUGC()->BInitWorkshopForGameServer(workshop, folder.utf8());
+	initialized_workshop = SteamUGC()->BInitWorkshopForGameServer(workshop, folder.utf8().get_data());
 	return initialized_workshop;
 }
 


### PR DESCRIPTION
[This PR](https://github.com/godotengine/godot/pull/101293) removes implicit CharString conversions, so we just needed a few `.get_data()`s to get back in action.

Is backward compatible.